### PR TITLE
Add an option to the graph tool to not show the coordinate hints in the lower left corner.

### DIFF
--- a/macros/parserGraphTool.pl
+++ b/macros/parserGraphTool.pl
@@ -146,6 +146,10 @@ graph as the default values for the options above:
 These restrict the x coordinate and y coordinate of points that can be graphed to being
 multiples of the respective parameter.  These values must be greater than zero.
 
+=item showCoordinateHints (Default: showCoordinateHints => 1)
+
+Set this to 0 to disable the display of the coordinates in the lower right corner of the graph.
+
 =item availableTools (Default: availableTools => [ "LineTool", "CircleTool",
 	"VerticalParabolaTool", "HorizontalParabolaTool", "FillTool", "SolidDashTool" ])
 
@@ -220,6 +224,7 @@ sub new {
 		gridX => 1, gridY => 1, snapSizeX => 1, snapSizeY => 1,
 		ticksDistanceX => 2, ticksDistanceY => 2,
 		minorTicksX => 1, minorTicksY => 1,
+		showCoordinateHints => 1,
 		availableTools => [
 			"LineTool",
 			"CircleTool",
@@ -513,6 +518,7 @@ END_TIKZ
 			"staticObjects: '" . join(',', @{$self->{staticObjects}}) . "'," .
 			"snapSizeX: $self->{snapSizeX}," .
 			"snapSizeY: $self->{snapSizeY}," .
+			"showCoordinateHints: $self->{showCoordinateHints}," .
 			"customGraphObjects: {$customGraphObjects}," .
 			"customTools: {$customTools}," .
 			"availableTools: ['" . join("','", @{$self->{availableTools}}) . "']," .


### PR DESCRIPTION
Make sure to also check out https://github.com/Alex-Jordan/webwork2/pull/12 or this won't do anything useful.

The following file is a problem with this option set.
[GraphPoint.pg.txt](https://github.com/Alex-Jordan/pg/files/7406289/GraphPoint.pg.txt)

Of course, you should also test with a problem that does not have this option set to see that the coordinates are still displayed as usual.

