### PR TITLE
Yet another approach at separation.  This time only the javascript and not the macro.

### DIFF
--- a/htdocs/js/apps/GraphTool/pointtool.js
+++ b/htdocs/js/apps/GraphTool/pointtool.js
@@ -1,0 +1,85 @@
+(function() {
+	if (graphTool && graphTool.pointTool) return;
+
+	graphTool.pointTool = {
+		graphObject: {
+			preInit: function(gt, x, y, color) {
+				return gt.board.create('point', [x, y], {
+					size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false,
+					strokeColor: color ? color : gt.underConstructionColor, fixed: gt.isStatic,
+					highlightStrokeColor: gt.underConstructionColor, highlightFillColor: gt.pointHighlightColor
+				});
+			},
+			postInit: function(gt) {
+				if (!gt.isStatic) {
+					this.on('down', function() { gt.board.containerObj.style.cursor = 'none'; });
+					this.on('up', function() { gt.board.containerObj.style.cursor = 'auto'; });
+					this.on('drag', gt.updateText);
+				}
+			},
+			blur: function(gt) {
+				this.baseObj.setAttribute({ highlight: false, strokeColor: gt.curveColor, strokeWidth: 2 });
+			},
+			focus: function(gt) {
+				this.baseObj.setAttribute({ highlight: true, strokeColor: gt.focusCurveColor, strokeWidth: 3 });
+			},
+			stringify: function(gt) {
+				return [
+					"(" + gt.snapRound(this.baseObj.X(), gt.snapSizeX) + "," +
+					gt.snapRound(this.baseObj.Y(), gt.snapSizeY) + ")"
+				].join(",");
+			},
+			updateTextCoords: function(gt, coords) {
+				if (this.baseObj.hasPoint(coords.scrCoords[1], coords.scrCoords[2]))
+					gt.setTextCoords(this.baseObj.X(), this.baseObj.Y());
+			},
+			restore: function(gt, string) {
+				var pointData;
+				var points = [];
+				while (pointData = gt.pointRegexp.exec(string))
+				{ points.push(pointData.slice(1, 3)); }
+				if (points.length < 1) return false;
+				return new gt.graphObjectTypes.point(parseFloat(points[0][0]), parseFloat(points[0][1]), gt.curveColor);
+			}
+		},
+		graphTool: {
+			iconName: "point",
+			tooltip: "Point Tool",
+			updateHighlights: function(gt, coords) {
+				if (typeof(coords) === 'undefined') return false;
+				if (!('hl_point' in this.hlObjs)) {
+					this.hlObjs.hl_point = gt.board.create('point', [coords.usrCoords[1], coords.usrCoords[2]], {
+						size: 2, color: gt.underConstructionColor, fixed: true, snapToGrid: true,
+						snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false
+					});
+				}
+				else
+					this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+
+				gt.setTextCoords(coords.usrCoords[1], coords.usrCoords[2]);
+				gt.board.update();
+				return true;
+			},
+			deactivate: function(gt) {
+				gt.board.off('up');
+				gt.board.containerObj.style.cursor = 'auto';
+			},
+			activate: function(gt) {
+				gt.board.containerObj.style.cursor = 'none';
+				var this_tool = this;
+				gt.board.on('up', function(e) {
+					var coords = gt.getMouseCoords(e);
+
+					// Don't allow the point to be created off the board
+					if (!gt.board.hasPoint(coords.usrCoords[1], coords.usrCoords[2])) return;
+					gt.board.off('up');
+
+					gt.selectedObj = new gt.graphObjectTypes.point(coords.usrCoords[1], coords.usrCoords[2]);
+					gt.graphedObjs.push(gt.selectedObj);
+
+					this_tool.finish();
+				});
+			}
+		}
+	};
+})();

--- a/macros/parserGraphTool.pl
+++ b/macros/parserGraphTool.pl
@@ -188,6 +188,7 @@ sub _parserGraphTool_init {
 	ADD_CSS_FILE("js/apps/GraphTool/graphtool.css");
 	ADD_JS_FILE("node_modules/jsxgraph/distrib/jsxgraphcore.js", 0, { defer => undef });
 	ADD_JS_FILE("js/apps/GraphTool/graphtool.min.js", 0, { defer => undef });
+	ADD_JS_FILE('js/apps/GraphTool/pointtool.js', 0, { defer => undef });
 
 	main::PG_restricted_eval('sub GraphTool { parser::GraphTool->new(@_) }');
 }
@@ -198,7 +199,6 @@ package parser::GraphTool;
 our @ISA = qw(Value::List);
 
 our %contextStrings = (
-	point => {},
 	line => {},
 	circle => {},
 	parabola => {},
@@ -356,6 +356,10 @@ sub addTools {
 	my %tools = @_;
 	$customTools .= join(",", map { "$_: $tools{$_}" } keys %tools) . ",";
 }
+
+# The point tool is available for use by default.  It is added this way so that the javascript can be kept separate.
+parser::GraphTool->addGraphObjects(point => { js => 'graphTool.pointTool.graphObject' });
+parser::GraphTool->addTools(PointTool => 'graphTool.pointTool.graphTool');
 
 sub ANS_NAME
 {


### PR DESCRIPTION
This moves the GraphTool point object and tool into a separate javascript file, but leaves it as part of the main macro.  So as far as authors are concerned it is all one macro.  However, this satisfies my primary desire to separate the javascript and make that more maintainable.