### PR TITLE
add test files to niceTables.pl macro

### DIFF
--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1270,43 +1270,6 @@ sub safetyFilter {
 	return ($answer, $errorno);
 }
 
-=head2 PGsort
-
-Because of the way sort is optimized in Perl, the symbols $a and $b
-have special significance.
-
-C<sort {$a<=>$b} @list>
-C<sort {$a cmp $b} @list>
-
-sorts the list numerically and lexically respectively.
-
-If C<my $a;> is used in a problem, before the sort routine is defined in a macro, then
-things get badly confused.  To correct this the macro PGsort is defined below.  It is
-evaluated before the problem template is read.  In PGbasicmacros.pl, the two subroutines
-
-    PGsort sub { $_[0] < $_[1] }, @list;
-    PGsort sub { $_[0] lt $_[1] }, @list;
-
-(called num_sort and lex_sort) provide slightly slower, but safer, routines for the PG language.
-(The subroutines for ordering are B<required>. Note the commas!)
-
-=cut
-
-sub PGsort {
-	my ($cmp, @list) = @_;
-	die "Must supply an ordering function with PGsort: PGsort sub {\$_[0]  < \$_[1] }, \@list\n"
-		unless ref $cmp eq 'CODE';
-
-	return if @list == 0;
-
-	my $b_item = shift @list;
-	my ($small, $large);
-	for my $a_item (@list) {
-		push @{ &$cmp($a_item, $b_item) ? $small : $large }, $a_item;
-	}
-	return PGsort($cmp, @$small), $b_item, PGsort($cmp, @$large);
-}
-
 =head2 PG_restricted_eval
 
     PG_restricted_eval($string)

--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1775,7 +1775,7 @@ sub Format {
 	if ($main::displayMode eq 'TeX') {
 		$format = "\n{\\pgmlSetup\n" . PGML::Format::tex->new($parser)->format . "\\par}%\n";
 	} elsif ($main::displayMode eq 'PTX') {
-		$format = PGML::Format::ptx->new($parser)->format . "\n";
+		$format = PGML::Format::ptx->new($parser)->format;
 		$format = main::PTX_cleanup($format);
 	} else {
 		$format = '<div class="PGML">' . "\n" . PGML::Format::html->new($parser)->format . '</div>' . "\n";

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2746,6 +2746,43 @@ sub uniq {
 	@out;
 }
 
+=head2 PGsort
+
+Because of the way sort is optimized in Perl, the symbols $a and $b
+have special significance.
+
+C<sort {$a<=>$b} @list>
+C<sort {$a cmp $b} @list>
+
+sorts the list numerically and lexically respectively.
+
+If C<my $a;> is used in a problem, before the sort routine is defined in a macro, then
+things get badly confused.  To correct this the macro PGsort is defined below.  It is
+evaluated before the problem template is read.  In PGbasicmacros.pl, the two subroutines
+
+    PGsort sub { $_[0] < $_[1] }, @list;
+    PGsort sub { $_[0] lt $_[1] }, @list;
+
+(called num_sort and lex_sort) provide slightly slower, but safer, routines for the PG language.
+(The subroutines for ordering are B<required>. Note the commas!)
+
+=cut
+
+sub PGsort {
+	my ($cmp, @list) = @_;
+	die "Must supply an ordering function with PGsort: PGsort sub {\$_[0]  < \$_[1] }, \@list\n"
+		unless ref $cmp eq 'CODE';
+
+	return if @list == 0;
+
+	my $b_item = shift @list;
+	my ($small, $large);
+	for my $a_item (@list) {
+		push @{ &$cmp($a_item, $b_item) ? $small : $large }, $a_item;
+	}
+	return PGsort($cmp, @$small), $b_item, PGsort($cmp, @$large);
+}
+
 sub lex_sort {
 	PGsort(sub { $_[0] lt $_[1] }, @_);
 }

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2371,7 +2371,7 @@ sub PTX_cleanup {
 	# Wrap <p> tags where necessary, and other cleanup
 	# Nothing else should be creating p tags, so assume all p tags created here
 	# The only supported top-level elements within a statement, hint, or solution in a problem
-	# are p, blockquote, pre, tabular, image, video
+	# are p, blockquote, pre, tabular, image, video, sbsgroup
 	if ($displayMode eq 'PTX') {
 		#encase entire string in <p>
 		#except not for certain "sub" structures that are also passed through EV3
@@ -2383,11 +2383,11 @@ sub PTX_cleanup {
 		$string =~ s/(<li[^>]*(?<!\/)>)/$1\n<p>/g;
 		$string =~ s/(<\/li>)/<\/p>\n$1/g;
 
-		#close p right before any blockquote, pre, image, video, or tabular
+		#close p right before any blockquote, pre, image, video, tabular, sbsgroup
 		#and open p immediately following. Later any potential side effects are cleaned up.
-		$string =~ s/(<(blockquote|pre|image|video|tabular)[^>]*(?<!\/)>)/<\/p>\n$1/g;
-		$string =~ s/(<\/(blockquote|pre|image|video|tabular)>)/$1\n<p>/g;
-		$string =~ s/(<(blockquote|pre|image|video|tabular)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
+		$string =~ s/(<(blockquote|pre|image|video|tabular|sbsgroup)[^>]*(?<!\/)>)/<\/p>\n$1/g;
+		$string =~ s/(<\/(blockquote|pre|image|video|tabular|sbsgroup)>)/$1\n<p>/g;
+		$string =~ s/(<(blockquote|pre|image|video|tabular|sbsgroup)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
 
 		#within a <cell>, we may have an issue if there was an image that had '<\p>' and '<p>' wrapped around
 		#it from the above block. If the '</p>' has a preceding '<p>' within the cell, no problem. Otherwise,

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -220,7 +220,7 @@ sub TableEnvironment {
 	my $tabulartype  = $hasX ? 'tabularx'                        : 'tabular';
 	my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
 	$tex = latexEnvironment($tex, $tabulartype, [ $tabularwidth, $tableOpts->{texalignment} ], ' ');
-	$tex = prefix($tex, '\centering') if $tableOpts->{center};
+	$tex = prefix($tex, '\centering')                      if $tableOpts->{center};
 	$tex = prefix($tex, '\renewcommand{\arraystretch}{2}') if $tableOpts->{LaYoUt};
 	$tex =
 		suffix($tex,
@@ -254,8 +254,7 @@ sub TableEnvironment {
 	}
 
 	# PTX
-	my $ptx = $cols;
-	$ptx = prefix($rows, $cols);
+	my $ptx     = $rows;
 	my $ptxleft = getPTXthickness($alignment[0]->{left});
 	my $ptxtop  = ($tableOpts->{horizontalrules}) ? 'major' : '';
 	$ptxtop = getPTXthickness($top) if $top;
@@ -273,18 +272,30 @@ sub TableEnvironment {
 		$ptxmargins = '0% 0%';
 	}
 	my $ptxbottom = ($tableOpts->{horizontalrules}) ? 'minor' : '';
-	$ptx = tag(
-		$ptx,
-		'tabular',
-		{
-			valign  => $tableOpts->{valign},
-			width   => $ptxwidth,
-			margins => $ptxmargins,
-			left    => $ptxleft,
-			top     => $ptxtop,
-			bottom  => $ptxbottom
-		}
-	);
+	if ($tableOpts->{LaYoUt}) {
+		$ptx = tag(
+			$ptx,
+			'sbsgroup',
+			{
+				width   => $ptxwidth,
+				margins => $ptxmargins,
+			}
+		);
+	} elsif (!$tableOpts->{LaYoUt}) {
+		$ptx = prefix($rows, $cols);
+		$ptx = tag(
+			$ptx,
+			'tabular',
+			{
+				valign  => $tableOpts->{valign},
+				width   => $ptxwidth,
+				margins => $ptxmargins,
+				left    => $ptxleft,
+				top     => $ptxtop,
+				bottom  => $ptxbottom
+			}
+		);
+	}
 
 	# We fake a caption as a following tabular
 	my $ptxcaption = '';
@@ -478,15 +489,61 @@ sub Rows {
 			$ptxleft = 'medium' if ($1 == '0.07em');
 			$ptxleft = 'major'  if ($1 == '0.11em');
 		}
-		$ptx = tag(
-			$ptx, 'row',
-			{
-				left   => $ptxleft,
-				valign => $valign,
-				header => $headerrow,
-				bottom => $ptxbottom
+		if ($tableOpts->{LaYoUt}) {
+			my $ptxwidthsum = 0;
+			my $ptxautocols = $colCount;
+			for my $j (1 .. $colCount) {
+				if ($rowOpts->[ $j - 1 ]->{width}) {
+					$ptxwidthsum += substr getWidthPercent($optsArray->[ $j - 1 ]->{width}), 0, -1;
+					$ptxautocols -= 1;
+				} elsif ($alignment->[$j]->{width}) {
+					$ptxwidthsum += substr getWidthPercent($alignment->[$j]->{width}), 0, -1;
+					$ptxautocols -= 1;
+				}
 			}
-		);
+			# determine if somewhere in the overall alignment, there are X columns
+			my $hasX = 0;
+			for my $align (@$alignment) {
+				if ($align->{halign} eq 'X') {
+					$hasX = 1;
+					last;
+				}
+			}
+			my $leftoverspace  = (($hasX) ? $tableOpts->{Xratio} * 100 : 100) - $ptxwidthsum;
+			my $divvyuptherest = 0;
+			$divvyuptherest = int($leftoverspace / $ptxautocols * 10000) / 10000 unless ($ptxautocols == 0);
+			my @ptxwidths;
+			for my $j (1 .. $colCount) {
+				if ($rowOpts->[ $j - 1 ]->{width}) {
+					push(@ptxwidths, getWidthPercent($rowOpts->[ $j - 1 ]->{width}));
+				} elsif ($alignment->[$j]->{width}) {
+					push(@ptxwidths, getWidthPercent($alignment->[$j]->{width}));
+				} else {
+					push(@ptxwidths, $divvyuptherest . '%');
+				}
+			}
+
+			my $ptxwidths = join(" ", @ptxwidths);
+			$ptx = tag(
+				$ptx,
+				'sidebyside',
+				{
+					valign  => ($valign) ? $valign : $tableOpts->{valign},
+					margins => '0% 0%',
+					widths  => $ptxwidths,
+				}
+			);
+		} else {
+			$ptx = tag(
+				$ptx, 'row',
+				{
+					left   => $ptxleft,
+					valign => $valign,
+					header => $headerrow,
+					bottom => $ptxbottom
+				}
+			);
+		}
 		push(@ptx, $ptx);
 	}
 
@@ -669,11 +726,13 @@ sub Row {
 		$ptx = wrap($ptx, @{ $tableOpts->{encase} })
 			unless $cellOpts->{noencase};
 
-		# space following p is intentional hack to prevent p from scrubbing by PTX cleanup
-		$ptx = wrap($ptx, '<p >', '</p >')
-			if ($alignment[$i]->{width}
+		$ptx = tag($ptx, 'p')
+			if ((
+				$alignment[$i]->{width}
 				or $alignment[$i]->{halign} eq 'X'
-				or $cellOpts->{halign} =~ /^p/);
+				or $cellOpts->{halign} =~ /^p/
+			))
+			&& !$tableOpts->{LaYoUt};
 		my $ptxhalign = '';
 		$ptxhalign = 'center' if ($cellOpts->{halign} =~ /c/);
 		$ptxhalign = 'right'  if ($cellOpts->{halign} =~ /r/);
@@ -688,14 +747,20 @@ sub Row {
 			$ptxright = 'medium' if ($1 == '0.07em');
 			$ptxright = 'major'  if ($1 == '0.11em');
 		}
-		$ptx = tag(
-			$ptx, 'cell',
-			{
-				halign  => $ptxhalign,
-				colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : '',
-				right   => $ptxright
-			}
-		);
+		if ($tableOpts->{LaYoUt}) {
+			$ptx = tag($ptx, 'p') unless ($cell =~ /<image[ >]/);
+			$ptx = tag($ptx, 'stack',);
+
+		} else {
+			$ptx = tag(
+				$ptx, 'cell',
+				{
+					halign  => $ptxhalign,
+					colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : '',
+					right   => $ptxright
+				}
+			);
+		}
 		push(@ptx, $ptx);
 	}
 
@@ -887,6 +952,7 @@ sub TableOptions {
 
 sub ParseAlignment {
 	my $alignment = shift;
+	$alignment =~ s/\R//g;
 
 	# first we parse things like *{20}{...} to expand them
 	my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -173,18 +173,17 @@ Options for ROWS
 sub _niceTables_init { };    # don't reload this file
 
 sub DataTable {
-    my $userArray = shift;
-    my $dataArray = DataArray($userArray);
-    my $optsArray = OptionsArray($userArray);
-    my $colCount  = ColumnCount($optsArray);
-    my $tableOpts = TableOptions( $colCount, @_ );
-    my $alignment = ParseAlignment( $tableOpts->{texalignment} );
-    TableEnvironment( $dataArray, $optsArray, $colCount, $tableOpts,
-        $alignment );
+	my $userArray = shift;
+	my $dataArray = DataArray($userArray);
+	my $optsArray = OptionsArray($userArray);
+	my $colCount  = ColumnCount($optsArray);
+	my $tableOpts = TableOptions($colCount, @_);
+	my $alignment = ParseAlignment($tableOpts->{texalignment});
+	TableEnvironment($dataArray, $optsArray, $colCount, $tableOpts, $alignment);
 }
 
 sub LayoutTable {
-    return DataTable( @_, LaYoUt => 1 );
+	return DataTable(@_, LaYoUt => 1);
 }
 
 # Make the outer table enovornment
@@ -194,960 +193,913 @@ sub LayoutTable {
 # encase, rowheaders should be passed to cells
 # various css should be self-explanatory
 sub TableEnvironment {
-    my ( $dataArray, $optsArray, $colCount, $tableOpts, $alignment ) = @_;
-    my @alignment = @$alignment;
+	my ($dataArray, $optsArray, $colCount, $tableOpts, $alignment) = @_;
+	my @alignment = @$alignment;
 
-    # determine if somewhere in the overall alignment, there are X columns
-    my $hasX = 0;
-    for my $align (@alignment) {
-        if ( $align->{halign} eq 'X' ) {
-            $hasX = 1;
-            last;
-        }
-    }
+	# determine if somewhere in the overall alignment, there are X columns
+	my $hasX = 0;
+	for my $align (@alignment) {
+		if ($align->{halign} eq 'X') {
+			$hasX = 1;
+			last;
+		}
+	}
 
-    # determine if first row has top
-    my $top;
-    for my $x ( @{ $optsArray->[0] } ) {
-        $top = $x->{top} if ( $x->{top} );
-    }
+	# determine if first row has top
+	my $top;
+	for my $x (@{ $optsArray->[0] }) {
+		$top = $x->{top} if ($x->{top});
+	}
 
-# get cols (only has some formatting specifications) and rows (the actual content)
-    my $cols = Cols( $alignment, $tableOpts, $optsArray );
-    my $rows =
-      Rows( $dataArray, $optsArray, $colCount, $tableOpts, $alignment );
+	# get cols (only has some formatting specifications) and rows (the actual content)
+	my $cols = Cols($alignment, $tableOpts, $optsArray);
+	my $rows = Rows($dataArray, $optsArray, $colCount, $tableOpts, $alignment);
 
-    # TeX
-    my $tex          = $rows;
-    my $tabulartype  = $hasX ? 'tabularx'                        : 'tabular';
-    my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
-    $tex = latexEnvironment( $tex, $tabulartype,
-        [ $tabularwidth, $tableOpts->{texalignment} ], ' ' );
-    $tex = prefix( $tex, '\centering' ) if $tableOpts->{center};
-    $tex = suffix( $tex,
-"\\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\\captionof*{table}{$tableOpts->{caption}}"
-    ) if ( $tableOpts->{caption} );
-    $tex = latexEnvironment( $tex, 'minipage', ['\linewidth'] );
-    $tex = wrap( $tex, '\par', '\par\vspace{1pc}' );
+	# TeX
+	my $tex          = $rows;
+	my $tabulartype  = $hasX ? 'tabularx'                        : 'tabular';
+	my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
+	$tex = latexEnvironment($tex, $tabulartype, [ $tabularwidth, $tableOpts->{texalignment} ], ' ');
+	$tex = prefix($tex, '\centering') if $tableOpts->{center};
+	$tex =
+		suffix($tex,
+			"\\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\\captionof*{table}{$tableOpts->{caption}}")
+		if ($tableOpts->{caption});
+	$tex = latexEnvironment($tex, 'minipage', ['\linewidth']);
+	$tex = wrap($tex, '\par', '\par\vspace{1pc}');
 
-    # HTML
-    my $css = $tableOpts->{tablecss};
-    if ($hasX) {
-        $css .= css( 'width', $tableOpts->{Xratio} * 100 . '%' );
-    }
-    $css .= css( 'border-left', getRuleCSS( $alignment[0]->{left} ) );
-    $css .= css( 'margin',      'auto' ) if $tableOpts->{center};
+	# HTML
+	my $css = $tableOpts->{tablecss};
+	if ($hasX) {
+		$css .= css('width', $tableOpts->{Xratio} * 100 . '%');
+	}
+	$css .= css('border-left', getRuleCSS($alignment[0]->{left}));
+	$css .= css('margin',      'auto') if $tableOpts->{center};
 
-    my $html     = $rows;
-    my $htmlcols = '';
-    $htmlcols = tag( $cols, 'colgroup' )
-      unless ( $cols =~ /^(<col>|\n)*$/ or $tableOpts->{LaYoUt} );
-    $html = prefix( $html, $htmlcols );
-    my $htmlcaption = tag( $tableOpts->{caption}, 'caption',
-        { style => $tableOpts->{captioncss} } );
-    $html = prefix( $html, $htmlcaption ) unless $tableOpts->{LaYoUt};
+	my $html     = $rows;
+	my $htmlcols = '';
+	$htmlcols = tag($cols, 'colgroup')
+		unless ($cols =~ /^(<col>|\n)*$/ or $tableOpts->{LaYoUt});
+	$html = prefix($html, $htmlcols);
+	my $htmlcaption = tag($tableOpts->{caption}, 'caption', { style => $tableOpts->{captioncss} });
+	$html = prefix($html, $htmlcaption) unless $tableOpts->{LaYoUt};
 
-    if ( $tableOpts->{LaYoUt} ) {
-        $css .= css( 'display',         'table' );
-        $css .= css( 'border-collapse', 'collapse' );
-        $html = tag( $html, 'div', { style => $css } );
-    }
-    else {
-        $html = tag( $html, 'table', { style => $css } );
-    }
+	if ($tableOpts->{LaYoUt}) {
+		$css .= css('display',         'table');
+		$css .= css('border-collapse', 'collapse');
+		$html = tag($html, 'div', { style => $css });
+	} else {
+		$html = tag($html, 'table', { style => $css });
+	}
 
-    # PTX
-    my $ptx = $cols;
-    $ptx = prefix( $rows, $cols );
-    my $ptxleft = getPTXthickness( $alignment[0]->{left} );
-    my $ptxtop  = ( $tableOpts->{horizontalrules} ) ? 'major' : '';
-    $ptxtop = getPTXthickness($top) if $top;
-    my $ptxwidth;
-    my $ptxmargins;
+	# PTX
+	my $ptx = $cols;
+	$ptx = prefix($rows, $cols);
+	my $ptxleft = getPTXthickness($alignment[0]->{left});
+	my $ptxtop  = ($tableOpts->{horizontalrules}) ? 'major' : '';
+	$ptxtop = getPTXthickness($top) if $top;
+	my $ptxwidth;
+	my $ptxmargins;
 
-    if ($hasX) {
-        $ptxwidth = $tableOpts->{Xratio} * 100;
-        my $leftmargin = ( $tableOpts->{center} ) ? ( 100 - $ptxwidth ) / 2 : 0;
-        my $rightmargin = 100 - $ptxwidth - $leftmargin;
-        $ptxmargins = "${leftmargin}% ${rightmargin}%";
-        $ptxwidth .= '%';
-    }
-    elsif ( !$tableOpts->{center} ) {
-        $ptxwidth   = '100%';
-        $ptxmargins = '0% 0%';
-    }
-    my $ptxbottom = ( $tableOpts->{horizontalrules} ) ? 'minor' : '';
-    $ptx = tag(
-        $ptx,
-        'tabular',
-        {
-            valign  => $tableOpts->{valign},
-            width   => $ptxwidth,
-            margins => $ptxmargins,
-            left    => $ptxleft,
-            top     => $ptxtop,
-            bottom  => $ptxbottom
-        }
-    );
+	if ($hasX) {
+		$ptxwidth = $tableOpts->{Xratio} * 100;
+		my $leftmargin  = ($tableOpts->{center}) ? (100 - $ptxwidth) / 2 : 0;
+		my $rightmargin = 100 - $ptxwidth - $leftmargin;
+		$ptxmargins = "${leftmargin}% ${rightmargin}%";
+		$ptxwidth .= '%';
+	} elsif (!$tableOpts->{center}) {
+		$ptxwidth   = '100%';
+		$ptxmargins = '0% 0%';
+	}
+	my $ptxbottom = ($tableOpts->{horizontalrules}) ? 'minor' : '';
+	$ptx = tag(
+		$ptx,
+		'tabular',
+		{
+			valign  => $tableOpts->{valign},
+			width   => $ptxwidth,
+			margins => $ptxmargins,
+			left    => $ptxleft,
+			top     => $ptxtop,
+			bottom  => $ptxbottom
+		}
+	);
 
-    # We fake a caption as a following tabular
-    my $ptxcaption = '';
-    if ( $tableOpts->{caption} ) {
-        $ptxcaption = $tableOpts->{caption};
-        $ptxcaption = tag( $ptxcaption, 'cell' );
-        $ptxcaption = tag( $ptxcaption, 'row' );
-        my $ptxcapwidth = '';
-        if ($hasX) {
-            $ptxcapwidth = $tableOpts->{Xratio} * 100 . '%';
-        }
-        else {
-            $ptxcapwidth = '50%';
-        }
-        $ptxcapcol  = tag( '', 'col', { width => $ptxcapwidth } );
-        $ptxcaption = prefix( $ptxcaption, $ptxcapcol );
-        $ptxcaption = tag( $ptxcaption, 'tabular',
-            { width => $ptxwidth, margins => $ptxmargins } );
-    }
-    $ptx = suffix( $ptx, $ptxcaption );
+	# We fake a caption as a following tabular
+	my $ptxcaption = '';
+	if ($tableOpts->{caption}) {
+		$ptxcaption = $tableOpts->{caption};
+		$ptxcaption = tag($ptxcaption, 'cell');
+		$ptxcaption = tag($ptxcaption, 'row');
+		my $ptxcapwidth = '';
+		if ($hasX) {
+			$ptxcapwidth = $tableOpts->{Xratio} * 100 . '%';
+		} else {
+			$ptxcapwidth = '50%';
+		}
+		$ptxcapcol  = tag('', 'col', { width => $ptxcapwidth });
+		$ptxcaption = prefix($ptxcaption, $ptxcapcol);
+		$ptxcaption = tag($ptxcaption, 'tabular', { width => $ptxwidth, margins => $ptxmargins });
+	}
+	$ptx = suffix($ptx, $ptxcaption);
 
-    MODES(
-        TeX  => $tex,
-        HTML => $html,
-        PTX  => $ptx,
-    );
+	MODES(
+		TeX  => $tex,
+		HTML => $html,
+		PTX  => $ptx,
+	);
 
 }
 
 sub Cols {
-    my ( $alignment, $tableOpts, $optsArray ) = @_;
-    my $columnscss = $tableOpts->{columnscss};
-    my @html;
-    my @ptx;
-    my @alignment = @$alignment;
-    my $leftend   = shift(@alignment);
+	my ($alignment, $tableOpts, $optsArray) = @_;
+	my $columnscss = $tableOpts->{columnscss};
+	my @html;
+	my @ptx;
+	my @alignment = @$alignment;
+	my $leftend   = shift(@alignment);
 
-    for my $i ( 0 .. $#alignment ) {
-        my $align = $alignment[$i];
+	for my $i (0 .. $#alignment) {
+		my $align = $alignment[$i];
 
-        # determine if this column has paragraph cells
-        my $width = '';
-        for my $y (@$optsArray) {
-            if ( $y->[$i]->{halign} =~ /^p\{([^}]*?)\}/ ) {
-                $width = $1;
-            }
-        }
+		# determine if this column has paragraph cells
+		my $width = '';
+		for my $y (@$optsArray) {
+			if ($y->[$i]->{halign} =~ /^p\{([^}]*?)\}/) {
+				$width = $1;
+			}
+		}
 
-        # HTML
-        my $htmlright = '';
-        $htmlright .= css( 'border-right', 'solid 2px' )
-          if ( $tableOpts->{rowheaders} && $i == 0 );
-        $htmlright .= css( 'border-right', getRuleCSS( $align->{right} ) );
+		# HTML
+		my $htmlright = '';
+		$htmlright .= css('border-right', 'solid 2px')
+			if ($tableOpts->{rowheaders} && $i == 0);
+		$htmlright .= css('border-right', getRuleCSS($align->{right}));
 
-        $htmlcolcss = $columnscss->[$i];
-        if ( $align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/ ) {
-            $htmlcolcss .= css( 'background-color', ( $1 ? '#' : '' ) . $2 );
-        }
+		$htmlcolcss = $columnscss->[$i];
+		if ($align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
+			$htmlcolcss .= css('background-color', ($1 ? '#' : '') . $2);
+		}
 
-        my $html = tag( '', 'col', { style => "${htmlright}${htmlcolcss}" } );
-        push( @html, $html );
+		my $html = tag('', 'col', { style => "${htmlright}${htmlcolcss}" });
+		push(@html, $html);
 
-        # PTX
-        my $ptxhalign = '';
-        $ptxhalign = 'center' if ( $align->{halign} eq 'c' );
-        $ptxhalign = 'right'  if ( $align->{halign} eq 'r' );
-        my $ptxright = '';
-        $ptxright = getPTXthickness( $align->{right} );
-        my $ptxwidth = '';
-        $ptxwidth = getWidthPercent( $align->{width} ) if $align->{width};
-        $ptxwidth = ( $tableOpts->{Xratio} / ( $#alignment + 1 ) * 100 ) . '%'
-          if ( $align->{halign} eq 'X' );
-        $ptxwidth = getWidthPercent($width) if $width;
-        my $ptx = tag(
-            '', 'col',
-            {
-                header => ( $tableOpts->{rowheaders} && $i == 0 ) ? 'yes' : '',
-                halign => $ptxhalign,
-                right  => $ptxright,
-                width  => $ptxwidth
-            }
-        );
-        push( @ptx, $ptx );
-    }
+		# PTX
+		my $ptxhalign = '';
+		$ptxhalign = 'center' if ($align->{halign} eq 'c');
+		$ptxhalign = 'right'  if ($align->{halign} eq 'r');
+		my $ptxright = '';
+		$ptxright = getPTXthickness($align->{right});
+		my $ptxwidth = '';
+		$ptxwidth = getWidthPercent($align->{width}) if $align->{width};
+		$ptxwidth = ($tableOpts->{Xratio} / ($#alignment + 1) * 100) . '%'
+			if ($align->{halign} eq 'X');
+		$ptxwidth = getWidthPercent($width) if $width;
+		my $ptx = tag(
+			'', 'col',
+			{
+				header => ($tableOpts->{rowheaders} && $i == 0) ? 'yes' : '',
+				halign => $ptxhalign,
+				right  => $ptxright,
+				width  => $ptxwidth
+			}
+		);
+		push(@ptx, $ptx);
+	}
 
-    $return = MODES(
-        HTML => join( "\n", @html ),
-        PTX  => join( "\n", @ptx )
-    );
+	$return = MODES(
+		HTML => join("\n", @html),
+		PTX  => join("\n", @ptx)
+	);
 
-    return $return;
+	return $return;
 
 }
 
 sub Rows {
-    my ( $dataArray, $optsArray, $colCount, $tableOpts, $alignment ) = @_;
-    my @data = @$dataArray;
+	my ($dataArray, $optsArray, $colCount, $tableOpts, $alignment) = @_;
+	my @data = @$dataArray;
 
-    my @tex;
-    my @htmlhead;
-    my @htmlbody;
-    my $stillinhtmlhead = 1;
-    my @ptx;
-    for my $i ( 0 .. $#data ) {
-        my $rowData = $data[$i];
-        my $rowOpts = $optsArray->[$i];
-        my $row     = Row( $rowData, $rowOpts, $tableOpts, $alignment );
+	my @tex;
+	my @htmlhead;
+	my @htmlbody;
+	my $stillinhtmlhead = 1;
+	my @ptx;
+	for my $i (0 .. $#data) {
+		my $rowData = $data[$i];
+		my $rowOpts = $optsArray->[$i];
+		my $row     = Row($rowData, $rowOpts, $tableOpts, $alignment);
 
-        # establish if this row has certain things
-        # non falsy last values are used
-        my $bottom    = 0;
-        my $top       = 0;
-        my $rowcolor  = '';
-        my $headerrow = '';
-        my $valign    = '';
-        for my $x (@$rowOpts) {
-            $bottom    = $x->{bottom}   if ( $x->{bottom} );
-            $top       = $x->{top}      if ( $x->{top} && $i == 0 );
-            $rowcolor  = $x->{rowcolor} if ( $x->{rowcolor} );
-            $headerrow = 'yes'          if ( $x->{headerrow} );
-            $valign    = $x->{valign}   if ( $x->{valign} );
-        }
+		# establish if this row has certain things
+		# non falsy last values are used
+		my $bottom    = 0;
+		my $top       = 0;
+		my $rowcolor  = '';
+		my $headerrow = '';
+		my $valign    = '';
+		for my $x (@$rowOpts) {
+			$bottom    = $x->{bottom}   if ($x->{bottom});
+			$top       = $x->{top}      if ($x->{top} && $i == 0);
+			$rowcolor  = $x->{rowcolor} if ($x->{rowcolor});
+			$headerrow = 'yes'          if ($x->{headerrow});
+			$valign    = $x->{valign}   if ($x->{valign});
+		}
 
-        # TeX
-        my $tex = $row;
+		# TeX
+		my $tex = $row;
 
-        # separator argument is space to avoid PGML catcode manipulation issues
-        $tex = prefix( $tex, "\\rowcolor{$rowcolor}", ' ' )
-          if ( $rowcolor =~ /^[^{]+$/ );
-        $tex = prefix( $tex, "\\rowcolor$rowcolor", ' ' )
-          if ( $rowcolor =~ /^(\[HTML\])?\{[^}]+\}/ );
-        $tex = prefix( $tex, "\\toprule", ' ' )
-          if ( $top || ( $i == 0 && $tableOpts->{horizontalrules} ) );
-        $tex = suffix( $tex, "\\\\",      ' ' ) unless ( $i == $#data );
-        $tex = suffix( $tex, "\\midrule", ' ' )
-          if ( $i < $#data && ( $bottom || $tableOpts->{horizontalrules} )
-            || $headerrow );
-        $tex = suffix( $tex, "\\\\\\bottomrule", ' ' )
-          if ( $i == $#data && ( $bottom or $tableOpts->{horizontalrules} ) );
-        push( @tex, $tex );
+		# separator argument is space to avoid PGML catcode manipulation issues
+		$tex = prefix($tex, "\\rowcolor{$rowcolor}", ' ')
+			if ($rowcolor =~ /^[^{]+$/);
+		$tex = prefix($tex, "\\rowcolor$rowcolor", ' ')
+			if ($rowcolor =~ /^(\[HTML\])?\{[^}]+\}/);
+		$tex = prefix($tex, "\\toprule", ' ')
+			if ($top || ($i == 0 && $tableOpts->{horizontalrules}));
+		$tex = suffix($tex, "\\\\",      ' ') unless ($i == $#data);
+		$tex = suffix($tex, "\\midrule", ' ')
+			if ($i < $#data && ($bottom || $tableOpts->{horizontalrules})
+				|| $headerrow);
+		$tex = suffix($tex, "\\\\\\bottomrule", ' ')
+			if ($i == $#data && ($bottom or $tableOpts->{horizontalrules}));
+		push(@tex, $tex);
 
-        # HTML
-        my $css = '';
-        for my $x (@$rowOpts) {
-            $css .= $x->{rowcss} if $x->{rowcss};
-        }
-        if ( $rowcolor =~ /(\[HTML\])?{(.*?)[}!]/ ) {
-            $css .= css( 'background-color', ( $1 ? '#' : '' ) . $2 );
-        }
-        else {
-            $css .= css( 'background-color', $rowcolor ) if $rowcolor;
-        }
-        $css .= css( 'border-top', 'solid 3px' )
-          if ( $i == 0 && $tableOpts->{horizontalrules} );
-        $css .= css( 'border-top',    getRuleCSS($top) );
-        $css .= css( 'border-bottom', 'solid 1px' )
-          if ( $i < $#data && $tableOpts->{horizontalrules} );
-        $css .= css( 'border-bottom', 'solid 3px' )
-          if ( $i == $#data && $tableOpts->{horizontalrules} );
-        $css .= css( 'border-bottom',  getRuleCSS($bottom) );
-        $css .= css( 'vertical-align', $valign );
-        my $html;
+		# HTML
+		my $css = '';
+		for my $x (@$rowOpts) {
+			$css .= $x->{rowcss} if $x->{rowcss};
+		}
+		if ($rowcolor =~ /(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('background-color', ($1 ? '#' : '') . $2);
+		} else {
+			$css .= css('background-color', $rowcolor) if $rowcolor;
+		}
+		$css .= css('border-top', 'solid 3px')
+			if ($i == 0 && $tableOpts->{horizontalrules});
+		$css .= css('border-top',    getRuleCSS($top));
+		$css .= css('border-bottom', 'solid 1px')
+			if ($i < $#data && $tableOpts->{horizontalrules});
+		$css .= css('border-bottom', 'solid 3px')
+			if ($i == $#data && $tableOpts->{horizontalrules});
+		$css .= css('border-bottom',  getRuleCSS($bottom));
+		$css .= css('vertical-align', $valign);
+		my $html;
 
-        if ( $tableOpts->{LaYoUt} ) {
-            $css .= css( 'display', 'table-row' );
-            $html = tag( $row, 'div', { style => $css } );
-            push( @htmlbody, $html );
-        }
-        else {
-            $html = tag( $row, 'tr', { style => $css } );
-            if ( $stillinhtmlhead && $headerrow ) {
-                push( @htmlhead, $html );
-            }
-            else {
-                $stillinhtmlhead = 0;
-                push( @htmlbody, $html );
-            }
-        }
+		if ($tableOpts->{LaYoUt}) {
+			$css .= css('display', 'table-row');
+			$html = tag($row, 'div', { style => $css });
+			push(@htmlbody, $html);
+		} else {
+			$html = tag($row, 'tr', { style => $css });
+			if ($stillinhtmlhead && $headerrow) {
+				push(@htmlhead, $html);
+			} else {
+				$stillinhtmlhead = 0;
+				push(@htmlbody, $html);
+			}
+		}
 
-        # PTX
-        my $ptx .= $row;
-        my $ptxbottom = '';
-        $ptxbottom = 'minor'
-          if ( $i < $#data && $tableOpts->{horizontalrules} );
-        $ptxbottom = 'major'
-          if ( $i == $#data && $tableOpts->{horizontalrules} );
-        $ptxbottom = getPTXthickness($bottom) if $bottom;
-        my $ptxleft = '';
-        $ptxleft = 'minor'  if ( $rowOpts->[0]->{halign} =~ /^\s*\|/ );
-        $ptxleft = 'medium' if ( $rowOpts->[0]->{halign} =~ /^\s*\|\s*\|/ );
-        $ptxleft = 'major' if ( $rowOpts->[0]->{halign} =~ /^\s*\|\s*\|\s*\|/ );
+		# PTX
+		my $ptx .= $row;
+		my $ptxbottom = '';
+		$ptxbottom = 'minor'
+			if ($i < $#data && $tableOpts->{horizontalrules});
+		$ptxbottom = 'major'
+			if ($i == $#data && $tableOpts->{horizontalrules});
+		$ptxbottom = getPTXthickness($bottom) if $bottom;
+		my $ptxleft = '';
+		$ptxleft = 'minor'  if ($rowOpts->[0]->{halign} =~ /^\s*\|/);
+		$ptxleft = 'medium' if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|/);
+		$ptxleft = 'major'  if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|\s*\|/);
 
-        if ( $rowOpts->[0]->{halign} =~
-            /^(?:\s|\|)*!{\s*\\vrule\s+width\s+([^}]*?)\s*}/ )
-        {
-            $ptxleft = 'minor'  if ($1);
-            $ptxleft = 'minor'  if ( $1 == '0.04em' );
-            $ptxleft = 'medium' if ( $1 == '0.07em' );
-            $ptxleft = 'major'  if ( $1 == '0.11em' );
-        }
-        $ptx = tag(
-            $ptx, 'row',
-            {
-                left   => $ptxleft,
-                valign => $valign,
-                header => $headerrow,
-                bottom => $ptxbottom
-            }
-        );
-        push( @ptx, $ptx );
-    }
+		if ($rowOpts->[0]->{halign} =~ /^(?:\s|\|)*!{\s*\\vrule\s+width\s+([^}]*?)\s*}/) {
+			$ptxleft = 'minor'  if ($1);
+			$ptxleft = 'minor'  if ($1 == '0.04em');
+			$ptxleft = 'medium' if ($1 == '0.07em');
+			$ptxleft = 'major'  if ($1 == '0.11em');
+		}
+		$ptx = tag(
+			$ptx, 'row',
+			{
+				left   => $ptxleft,
+				valign => $valign,
+				header => $headerrow,
+				bottom => $ptxbottom
+			}
+		);
+		push(@ptx, $ptx);
+	}
 
-    my $htmlout;
-    if ( $tableOpts->{LaYoUt} ) {
-        $htmlout = join( "\n", @htmlbody );
-    }
-    else {
-        my $htmlvalign = '';
-        $htmlvalign = $tableOpts->{valign}
-          unless ( $tableOpts->{valign} eq 'middle' );
-        $htmlout = tag( join( "\n", @htmlbody ),
-            'tbody', { style => css( 'vertical-align', $htmlvalign ) } );
-        $htmlout = prefix(
-            $htmlout,
-            tag(
-                join( "\n", @htmlhead ),
-                'thead',
-                {
-                    style => css( 'vertical-align', $htmlvalign )
-                      . css( 'border-bottom', 'solid 2px' )
-                }
-            )
-        ) if (@htmlhead);
-    }
+	my $htmlout;
+	if ($tableOpts->{LaYoUt}) {
+		$htmlout = join("\n", @htmlbody);
+	} else {
+		my $htmlvalign = '';
+		$htmlvalign = $tableOpts->{valign}
+			unless ($tableOpts->{valign} eq 'middle');
+		$htmlout = tag(join("\n", @htmlbody), 'tbody', { style => css('vertical-align', $htmlvalign) });
+		$htmlout = prefix(
+			$htmlout,
+			tag(
+				join("\n", @htmlhead),
+				'thead',
+				{
+					style => css('vertical-align', $htmlvalign) . css('border-bottom', 'solid 2px')
+				}
+			)
+		) if (@htmlhead);
+	}
 
-    $return = MODES(
-        TeX  => join( " ", @tex ),
-        HTML => $htmlout,
-        PTX  => join( "\n", @ptx ),
-    );
+	$return = MODES(
+		TeX  => join(" ", @tex),
+		HTML => $htmlout,
+		PTX  => join("\n", @ptx),
+	);
 
-    return $return;
+	return $return;
 
 }
 
 sub Row {
-    my ( $rowData, $rowOpts, $tableOpts, $alignment ) = @_;
-    my @alignment = @$alignment;
-    my $leftend   = shift(@alignment);
-    my @data      = @$rowData;
-    my $headerrow = '';
-    my $valign    = '';
-    for my $x (@$rowOpts) {
-        $headerrow = 'yes'        if ( $x->{headerrow} );
-        $valign    = $x->{valign} if ( $x->{valign} );
-    }
+	my ($rowData, $rowOpts, $tableOpts, $alignment) = @_;
+	my @alignment = @$alignment;
+	my $leftend   = shift(@alignment);
+	my @data      = @$rowData;
+	my $headerrow = '';
+	my $valign    = '';
+	for my $x (@$rowOpts) {
+		$headerrow = 'yes'        if ($x->{headerrow});
+		$valign    = $x->{valign} if ($x->{valign});
+	}
 
-    my @tex;
-    my @html;
-    my @ptx;
-    for my $i ( 0 .. $#data ) {
-        my $cellOpts = $rowOpts->[$i];
-        my $cell     = $data[$i];
+	my @tex;
+	my @html;
+	my @ptx;
+	for my $i (0 .. $#data) {
+		my $cellOpts = $rowOpts->[$i];
+		my $cell     = $data[$i];
 
-        # TeX
-        my $tex = $cell;
-        $tex = prefix( $tex, $cellOpts->{tex} );
-        $tex = wrap( $tex, @{ $tableOpts->{encase} } )
-          unless $cellOpts->{noencase};
-        $tex = wrap( $tex, $cellOpts->{texpre}, $cellOpts->{texpost} );
-        $tex = prefix( $tex, '\bfseries' )
-          if ( $tableOpts->{rowheaders} and $i == 0
-            or $headerrow
-            or $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i );
-        if (   $cellOpts->{colspan} > 1
-            or $cellOpts->{halign}
-            or $valign
-            or ( $tableOpts->{valign} && $tableOpts->{valign} ne 'top' ) )
-        {
-            my $columntype = $cellOpts->{halign};
-            $columntype = $alignment[$i]->{halign} // 'l' unless $columntype;
-            $columntype =
-              'p{' . $tableOpts->{Xratio} / ( $#data + 1 ) . "\\linewidth}"
-              if ( $columntype eq 'X' );
-            $columntype = "p{$alignment[$i]->{width}}"
-              if ( $alignment[$i]->{width} );
-            $columntype =~ s/^p/m/ if ( $valign eq 'middle' );
-            $columntype =~ s/^p/b/ if ( $valign eq 'bottom' );
-            $columntype =~ s/^p/m/ if ( $tableOpts->{valign} eq 'middle' );
-            $columntype =~ s/^p/b/ if ( $tableOpts->{valign} eq 'bottom' );
-            $tex = latexCommand( 'multicolumn',
-                [ $cellOpts->{colspan}, $columntype, $tex ] );
-        }
-        $tex = suffix( $tex, '&', ' ' ) unless ( $i == $#data );
-        push( @tex, $tex );
+		# TeX
+		my $tex = $cell;
+		$tex = prefix($tex, $cellOpts->{tex});
+		$tex = wrap($tex, @{ $tableOpts->{encase} })
+			unless $cellOpts->{noencase};
+		$tex = wrap($tex, $cellOpts->{texpre}, $cellOpts->{texpost});
+		$tex = prefix($tex, '\bfseries')
+			if ($tableOpts->{rowheaders} and $i == 0
+				or $headerrow
+				or $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i);
+		if ($cellOpts->{colspan} > 1
+			or $cellOpts->{halign}
+			or $valign
+			or ($tableOpts->{valign} && $tableOpts->{valign} ne 'top'))
+		{
+			my $columntype = $cellOpts->{halign};
+			$columntype = $alignment[$i]->{halign} // 'l' unless $columntype;
+			$columntype = 'p{' . $tableOpts->{Xratio} / ($#data + 1) . "\\linewidth}"
+				if ($columntype eq 'X');
+			$columntype = "p{$alignment[$i]->{width}}"
+				if ($alignment[$i]->{width});
+			$columntype =~ s/^p/m/ if ($valign eq 'middle');
+			$columntype =~ s/^p/b/ if ($valign eq 'bottom');
+			$columntype =~ s/^p/m/ if ($tableOpts->{valign} eq 'middle');
+			$columntype =~ s/^p/b/ if ($tableOpts->{valign} eq 'bottom');
+			$tex = latexCommand('multicolumn', [ $cellOpts->{colspan}, $columntype, $tex ]);
+		}
+		$tex = suffix($tex, '&', ' ') unless ($i == $#data);
+		push(@tex, $tex);
 
-        # HTML
-        my $t     = 'td';
-        my $scope = '';
-        $t = 'th' and $scope = 'row' if ( $i == 0 && $tableOpts->{rowheaders} );
-        $t = 'th' and $scope = 'col' if ($headerrow);
-        $t = 'th' if ( $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i );
-        $scope = 'row' if ( $cellOpts->{header} =~ /^(rh|row)$/i );
-        $scope = 'col' if ( $cellOpts->{header} =~ /^(ch|col|column)$/i );
-        $t     = 'td' and $scope = '' if ( $cellOpts->{header} =~ /^td$/i );
-        my $css = '';
+		# HTML
+		my $t     = 'td';
+		my $scope = '';
+		$t     = 'th' and $scope = 'row' if ($i == 0 && $tableOpts->{rowheaders});
+		$t     = 'th' and $scope = 'col' if ($headerrow);
+		$t     = 'th'                 if ($cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i);
+		$scope = 'row'                if ($cellOpts->{header} =~ /^(rh|row)$/i);
+		$scope = 'col'                if ($cellOpts->{header} =~ /^(ch|col|column)$/i);
+		$t     = 'td' and $scope = '' if ($cellOpts->{header} =~ /^td$/i);
+		my $css = '';
 
-        # col level
-        $css .= css( 'text-align', 'center' )
-          if ( $alignment[$i]->{halign} eq 'c' );
-        $css .= css( 'text-align', 'right' )
-          if ( $alignment[$i]->{halign} eq 'r' );
-        $css .= css( 'width', $alignment[$i]->{width} )
-          if ( $alignment[$i]->{width} );
-        $css .= css( 'font-weight', 'bold' )
-          if ( $alignment[$i]->{tex} =~ /\\bfseries/ );
-        $css .= css( 'font-style', 'italic' )
-          if ( $alignment[$i]->{tex} =~ /\\itshape/ );
-        $css .= css( 'font-family', 'monospace' )
-          if ( $alignment[$i]->{tex} =~ /\\ttfamily/ );
-        if ( $alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/ ) {
-            $css .= css( 'color', ( $1 ? '#' : '' ) . $2 );
-        }
+		# col level
+		$css .= css('text-align', 'center')
+			if ($alignment[$i]->{halign} eq 'c');
+		$css .= css('text-align', 'right')
+			if ($alignment[$i]->{halign} eq 'r');
+		$css .= css('width', $alignment[$i]->{width})
+			if ($alignment[$i]->{width});
+		$css .= css('font-weight', 'bold')
+			if ($alignment[$i]->{tex} =~ /\\bfseries/);
+		$css .= css('font-style', 'italic')
+			if ($alignment[$i]->{tex} =~ /\\itshape/);
+		$css .= css('font-family', 'monospace')
+			if ($alignment[$i]->{tex} =~ /\\ttfamily/);
+		if ($alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('color', ($1 ? '#' : '') . $2);
+		}
 
-        # cell level
-        $css .= $cellOpts->{cellcss};
-        if ( $cellOpts->{halign} =~ /^([|\s]*\|)/ && $i == 0 ) {
-            my $count = $1 =~ tr/\|//;
-            $css .= css( 'border-left', "solid ${count}px" );
-        }
-        if (   $cellOpts->{halign} =~ /^(\s\|)*!{\\vrule\s+width\s+([^}]*?)}/
-            && $i == 0 )
-        {
-            $css .= css( 'border-left', "solid $2" );
-        }
-        if ( $cellOpts->{halign} =~ /(\|[|\s]*)$/ ) {
-            my $count = $1 =~ tr/\|//;
-            $css .= css( 'border-right', "solid ${count}px" );
-        }
-        if ( $cellOpts->{halign} =~ /!{\\vrule\s+width\s+([^}]*?)}\s*$/ ) {
-            $css .= css( 'border-right', "solid $1" );
-        }
-        $css .= css( 'text-align', 'left' ) if ( $cellOpts->{halign} =~ /^l/ );
-        $css .= css( 'text-align', 'center' )
-          if ( $cellOpts->{halign} =~ /^c/ );
-        $css .= css( 'text-align', 'right' ) if ( $cellOpts->{halign} =~ /^r/ );
-        $css .= css( 'text-align', 'left' )  if ( $cellOpts->{halign} =~ /^p/ );
-        $css .= css( 'width', $1 ) if ( $cellOpts->{halign} =~ /^p{([^}]*?)}/ );
-        $css .= css( 'font-weight', 'bold' )
-          if ( $cellOpts->{tex} =~ /\\bfseries/ );
-        $css .= css( 'font-style', 'italic' )
-          if ( $cellOpts->{tex} =~ /\\itshape/ );
-        $css .= css( 'font-family', 'monospace' )
-          if ( $cellOpts->{tex} =~ /\\ttfamily/ );
+		# cell level
+		$css .= $cellOpts->{cellcss};
+		if ($cellOpts->{halign} =~ /^([|\s]*\|)/ && $i == 0) {
+			my $count = $1 =~ tr/\|//;
+			$css .= css('border-left', "solid ${count}px");
+		}
+		if ($cellOpts->{halign} =~ /^(\s\|)*!{\\vrule\s+width\s+([^}]*?)}/
+			&& $i == 0)
+		{
+			$css .= css('border-left', "solid $2");
+		}
+		if ($cellOpts->{halign} =~ /(\|[|\s]*)$/) {
+			my $count = $1 =~ tr/\|//;
+			$css .= css('border-right', "solid ${count}px");
+		}
+		if ($cellOpts->{halign} =~ /!{\\vrule\s+width\s+([^}]*?)}\s*$/) {
+			$css .= css('border-right', "solid $1");
+		}
+		$css .= css('text-align', 'left') if ($cellOpts->{halign} =~ /^l/);
+		$css .= css('text-align', 'center')
+			if ($cellOpts->{halign} =~ /^c/);
+		$css .= css('text-align',  'right') if ($cellOpts->{halign} =~ /^r/);
+		$css .= css('text-align',  'left')  if ($cellOpts->{halign} =~ /^p/);
+		$css .= css('width',       $1)      if ($cellOpts->{halign} =~ /^p{([^}]*?)}/);
+		$css .= css('font-weight', 'bold')
+			if ($cellOpts->{tex} =~ /\\bfseries/);
+		$css .= css('font-style', 'italic')
+			if ($cellOpts->{tex} =~ /\\itshape/);
+		$css .= css('font-family', 'monospace')
+			if ($cellOpts->{tex} =~ /\\ttfamily/);
 
-        if ( $cellOpts->{tex} =~ /\\cellcolor(\[HTML\])?{(.*?)[}!]/ ) {
-            $css .= css( 'background-color', ( $1 ? '#' : '' ) . $2 );
-        }
-        if ( $cellOpts->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/ ) {
-            $css .= css( 'color', ( $1 ? '#' : '' ) . $2 );
-        }
-        $css .= $tableOpts->{allcellcss};
-        $css .= $tableOpts->{headercss} if ( $t eq 'th' );
-        $css .= $tableOpts->{datacss}   if ( $t eq 'td' );
-        my $html = $cell;
-        $html = wrap( $cell, @{ $tableOpts->{encase} } )
-          unless $cellOpts->{noencase};
-        if ( $tableOpts->{LaYoUt} ) {
-            $css .= css( 'display', 'table-cell' );
-            my $cellvalign = $tableOpts->{valign};
-            $cellvalign = $valign if ($valign);
-            $css        = css( 'vertical-align', $cellvalign ) . $css;
-            $css        = css( 'padding',        '12pt' ) . $css;
-            if ( $alignment[$i]->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/ )
-            {
-                $css = css( 'background-color', ( $1 ? '#' : '' ) . $2 ) . $css;
-            }
-            $css = css( 'border-right', getRuleCSS( $alignment[$i]->{right} ) )
-              . $css;
-            $html = tag( $html, 'div', { style => $css } );
-        }
-        else {
-            $css  = css( 'padding', '0pt 6pt' ) . $css;
-            $html = tag(
-                $html, $t,
-                {
-                    style   => $css,
-                    scope   => $scope,
-                    colspan => ( $cellOpts->{colspan} > 1 )
-                    ? $cellOpts->{colspan}
-                    : ''
-                }
-            );
-        }
-        push( @html, $html );
+		if ($cellOpts->{tex} =~ /\\cellcolor(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('background-color', ($1 ? '#' : '') . $2);
+		}
+		if ($cellOpts->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('color', ($1 ? '#' : '') . $2);
+		}
+		$css .= $tableOpts->{allcellcss};
+		$css .= $tableOpts->{headercss} if ($t eq 'th');
+		$css .= $tableOpts->{datacss}   if ($t eq 'td');
+		my $html = $cell;
+		$html = wrap($cell, @{ $tableOpts->{encase} })
+			unless $cellOpts->{noencase};
+		if ($tableOpts->{LaYoUt}) {
+			$css .= css('display', 'table-cell');
+			my $cellvalign = $tableOpts->{valign};
+			$cellvalign = $valign if ($valign);
+			$css        = css('vertical-align', $cellvalign) . $css;
+			$css        = css('padding',        '12pt') . $css;
+			if ($alignment[$i]->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
+				$css = css('background-color', ($1 ? '#' : '') . $2) . $css;
+			}
+			$css  = css('border-right', getRuleCSS($alignment[$i]->{right})) . $css;
+			$html = tag($html, 'div', { style => $css });
+		} else {
+			$css  = css('padding', '0pt 6pt') . $css;
+			$html = tag(
+				$html, $t,
+				{
+					style   => $css,
+					scope   => $scope,
+					colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : ''
+				}
+			);
+		}
+		push(@html, $html);
 
-        # PTX
-        my $ptx = $cell;
-        $ptx = wrap( $ptx, @{ $tableOpts->{encase} } )
-          unless $cellOpts->{noencase};
+		# PTX
+		my $ptx = $cell;
+		$ptx = wrap($ptx, @{ $tableOpts->{encase} })
+			unless $cellOpts->{noencase};
 
-# space following p is intentional hack to prevent p from scrubbing by PTX cleanup
-        $ptx = wrap( $ptx, '<p >', '</p >' )
-          if ( $alignment[$i]->{width}
-            or $alignment[$i]->{halign} eq 'X'
-            or $cellOpts->{halign} =~ /^p/ );
-        my $ptxhalign = '';
-        $ptxhalign = 'center' if ( $cellOpts->{halign} =~ /c/ );
-        $ptxhalign = 'right'  if ( $cellOpts->{halign} =~ /r/ );
-        my $ptxright = '';
-        $ptxright = 'minor'  if ( $cellOpts->{halign} =~ /\|\s*$/ );
-        $ptxright = 'medium' if ( $cellOpts->{halign} =~ /\|\s*\|\s*$/ );
-        $ptxright = 'major'  if ( $cellOpts->{halign} =~ /\|\s*\|\s*\|\s*$/ );
+		# space following p is intentional hack to prevent p from scrubbing by PTX cleanup
+		$ptx = wrap($ptx, '<p >', '</p >')
+			if ($alignment[$i]->{width}
+				or $alignment[$i]->{halign} eq 'X'
+				or $cellOpts->{halign} =~ /^p/);
+		my $ptxhalign = '';
+		$ptxhalign = 'center' if ($cellOpts->{halign} =~ /c/);
+		$ptxhalign = 'right'  if ($cellOpts->{halign} =~ /r/);
+		my $ptxright = '';
+		$ptxright = 'minor'  if ($cellOpts->{halign} =~ /\|\s*$/);
+		$ptxright = 'medium' if ($cellOpts->{halign} =~ /\|\s*\|\s*$/);
+		$ptxright = 'major'  if ($cellOpts->{halign} =~ /\|\s*\|\s*\|\s*$/);
 
-        if ( $cellOpts->{halign} =~ /!{\s*\\vrule\s+width\s+([^}]*?)\s*}\s*$/ )
-        {
-            $ptxright = 'minor'  if ($1);
-            $ptxright = 'minor'  if ( $1 == '0.04em' );
-            $ptxright = 'medium' if ( $1 == '0.07em' );
-            $ptxright = 'major'  if ( $1 == '0.11em' );
-        }
-        $ptx = tag(
-            $ptx, 'cell',
-            {
-                halign  => $ptxhalign,
-                colspan => ( $cellOpts->{colspan} > 1 )
-                ? $cellOpts->{colspan}
-                : '',
-                right => $ptxright
-            }
-        );
-        push( @ptx, $ptx );
-    }
+		if ($cellOpts->{halign} =~ /!{\s*\\vrule\s+width\s+([^}]*?)\s*}\s*$/) {
+			$ptxright = 'minor'  if ($1);
+			$ptxright = 'minor'  if ($1 == '0.04em');
+			$ptxright = 'medium' if ($1 == '0.07em');
+			$ptxright = 'major'  if ($1 == '0.11em');
+		}
+		$ptx = tag(
+			$ptx, 'cell',
+			{
+				halign  => $ptxhalign,
+				colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : '',
+				right   => $ptxright
+			}
+		);
+		push(@ptx, $ptx);
+	}
 
-    $return = MODES(
-        TeX  => join( " ",  @tex ),
-        HTML => join( "\n", @html ),
-        PTX  => join( "\n", @ptx ),
-    );
+	$return = MODES(
+		TeX  => join(" ",  @tex),
+		HTML => join("\n", @html),
+		PTX  => join("\n", @ptx),
+	);
 
-    return $return;
+	return $return;
 
 }
 
 # Takes the original nested array and returns a simplified version with only the content
 # Also returns the true column count, accounting for colspan
 sub DataArray {
-    my $originalArrayRef = shift;
-    my @originalArray    = @$originalArrayRef;
-    my $lastRowIndex     = $#originalArray;
-    my @outArray;
-    for my $i ( 0 .. $lastRowIndex ) {
-        my @outRow;
-        my $originalRowRef = $originalArray[$i];
-        my @originalRow    = @$originalRowRef;
-        my $lastColIndex   = $#originalRow;
-        for my $j ( 0 .. $lastColIndex ) {
-            my $originalCell = $originalRow[$j];
-            my $outCell;
-            if ( ref($originalCell) eq 'HASH' ) {
-                $outCell = $originalCell->{'data'};
-            }
-            elsif ( ref($originalCell) eq 'ARRAY' ) {
-                $outCell = $originalCell->[0];
-            }
-            else {
-                $outCell = $originalCell;
-            }
-            $outRow[$j] = $outCell;
-        }
-        my $outRowRef = \@outRow;
-        $outArray[$i] = $outRowRef;
-    }
-    $outArrayRef = \@outArray;
-    return $outArrayRef;
+	my $originalArrayRef = shift;
+	my @originalArray    = @$originalArrayRef;
+	my $lastRowIndex     = $#originalArray;
+	my @outArray;
+	for my $i (0 .. $lastRowIndex) {
+		my @outRow;
+		my $originalRowRef = $originalArray[$i];
+		my @originalRow    = @$originalRowRef;
+		my $lastColIndex   = $#originalRow;
+		for my $j (0 .. $lastColIndex) {
+			my $originalCell = $originalRow[$j];
+			my $outCell;
+			if (ref($originalCell) eq 'HASH') {
+				$outCell = $originalCell->{'data'};
+			} elsif (ref($originalCell) eq 'ARRAY') {
+				$outCell = $originalCell->[0];
+			} else {
+				$outCell = $originalCell;
+			}
+			$outRow[$j] = $outCell;
+		}
+		my $outRowRef = \@outRow;
+		$outArray[$i] = $outRowRef;
+	}
+	$outArrayRef = \@outArray;
+	return $outArrayRef;
 }
 
 # Takes the original nested array and returns a simplified version with only the options as a hash
 sub OptionsArray {
-    my $originalArrayRef = shift;
-    my @originalArray    = @$originalArrayRef;
-    my $lastRowIndex     = $#originalArray;
-    my %supportedOptions = (
-        halign    => '',
-        header    => '',
-        tex       => '',
-        noencase  => 0,
-        colspan   => 1,
-        cellcss   => '',
-        texpre    => '',
-        texpost   => '',
-        rowcolor  => '',
-        rowcss    => '',
-        headerrow => '',
-        top       => 0,
-        bottom    => 0,
-        valign    => '',
-    );
-    my @outArray;
-    for my $i ( 0 .. $lastRowIndex ) {
-        my @outRow;
-        my $originalRowRef = $originalArray[$i];
-        my @originalRow    = @$originalRowRef;
-        my $lastColIndex   = $#originalRow;
-        for my $j ( 0 .. $lastColIndex ) {
-            my $originalCell = $originalRow[$j];
-            my $outCell;
-            my %outHash = %supportedOptions;
-            if ( ref($originalCell) eq 'HASH' ) {
-                for my $key ( keys(%supportedOptions) ) {
-                    $outHash{$key} = $originalCell->{$key}
-                      if defined( $originalCell->{$key} );
-                }
+	my $originalArrayRef = shift;
+	my @originalArray    = @$originalArrayRef;
+	my $lastRowIndex     = $#originalArray;
+	my %supportedOptions = (
+		halign    => '',
+		header    => '',
+		tex       => '',
+		noencase  => 0,
+		colspan   => 1,
+		cellcss   => '',
+		texpre    => '',
+		texpost   => '',
+		rowcolor  => '',
+		rowcss    => '',
+		headerrow => '',
+		top       => 0,
+		bottom    => 0,
+		valign    => '',
+	);
+	my @outArray;
+	for my $i (0 .. $lastRowIndex) {
+		my @outRow;
+		my $originalRowRef = $originalArray[$i];
+		my @originalRow    = @$originalRowRef;
+		my $lastColIndex   = $#originalRow;
+		for my $j (0 .. $lastColIndex) {
+			my $originalCell = $originalRow[$j];
+			my $outCell;
+			my %outHash = %supportedOptions;
+			if (ref($originalCell) eq 'HASH') {
+				for my $key (keys(%supportedOptions)) {
+					$outHash{$key} = $originalCell->{$key}
+						if defined($originalCell->{$key});
+				}
 
-                # convenience
-                $outHash{tex} .= '\bfseries' if ( $originalCell->{b} );
-                $outHash{tex} .= '\itshape'  if ( $originalCell->{i} );
-                $outHash{tex} .= '\ttfamily' if ( $originalCell->{m} );
-                $outHash{texpre} =
-                  $outHash{texpre} . $originalCell->{texencase}->[0]
-                  if $originalCell->{texencase};
-                $outHash{texpost} =
-                  $originalCell->{texencase}->[1] . $outHash{texpost}
-                  if $originalCell->{texencase};
+				# convenience
+				$outHash{tex} .= '\bfseries' if ($originalCell->{b});
+				$outHash{tex} .= '\itshape'  if ($originalCell->{i});
+				$outHash{tex} .= '\ttfamily' if ($originalCell->{m});
+				$outHash{texpre} = $outHash{texpre} . $originalCell->{texencase}->[0]
+					if $originalCell->{texencase};
+				$outHash{texpost} = $originalCell->{texencase}->[1] . $outHash{texpost}
+					if $originalCell->{texencase};
 
-                # legacy misnomers
-                $outHash{bottom} = $originalCell->{midrule}
-                  if ( defined( $originalCell->{midrule} )
-                    && !$outHash{bottom} );
-            }
-            elsif ( ref($originalCell) eq 'ARRAY' ) {
-                my @originalOptions = (@$originalCell);
-                my $data            = shift(@originalOptions);
-                my %originalOptions = @originalOptions;
-                for my $key ( keys(%supportedOptions) ) {
-                    $outHash{$key} = $originalOptions{$key}
-                      if defined( $originalOptions{$key} );
-                }
+				# legacy misnomers
+				$outHash{bottom} = $originalCell->{midrule}
+					if (defined($originalCell->{midrule})
+						&& !$outHash{bottom});
+			} elsif (ref($originalCell) eq 'ARRAY') {
+				my @originalOptions = (@$originalCell);
+				my $data            = shift(@originalOptions);
+				my %originalOptions = @originalOptions;
+				for my $key (keys(%supportedOptions)) {
+					$outHash{$key} = $originalOptions{$key}
+						if defined($originalOptions{$key});
+				}
 
-                # convenience
-                $outHash{tex} .= '\bfseries' if ( $originalOptions{b} );
-                $outHash{tex} .= '\itshape'  if ( $originalOptions{i} );
-                $outHash{tex} .= '\ttfamily' if ( $originalOptions{m} );
-                $outHash{texpre} =
-                  $outHash{texpre} . $originalOptions{texencase}->[0]
-                  if $originalOptions{texencase};
-                $outHash{texpost} =
-                  $originalOptions{texencase}->[1] . $outHash{texpost}
-                  if $originalOptions{texencase};
+				# convenience
+				$outHash{tex} .= '\bfseries' if ($originalOptions{b});
+				$outHash{tex} .= '\itshape'  if ($originalOptions{i});
+				$outHash{tex} .= '\ttfamily' if ($originalOptions{m});
+				$outHash{texpre} = $outHash{texpre} . $originalOptions{texencase}->[0]
+					if $originalOptions{texencase};
+				$outHash{texpost} = $originalOptions{texencase}->[1] . $outHash{texpost}
+					if $originalOptions{texencase};
 
-                # legacy misnomers
-                $outHash{bottom} = $originalOptions{midrule}
-                  if ( defined( $originalOptions{midrule} )
-                    && !$outHash{bottom} );
-            }
+				# legacy misnomers
+				$outHash{bottom} = $originalOptions{midrule}
+					if (defined($originalOptions{midrule})
+						&& !$outHash{bottom});
+			}
 
-            # clean up
-            # remove any left vertical rule specifications from halign
-            if (   $j > 0
-                && $outHash{halign} =~
-                /((?<!\w)[lcrp](?!\w)\s*(\{[^}]*?\})?(\||!\{[^}]*?\}|\s)*)/ )
-            {
-                $outHash{halign} = $1;
-            }
+			# clean up
+			# remove any left vertical rule specifications from halign
+			if ($j > 0
+				&& $outHash{halign} =~ /((?<!\w)[lcrp](?!\w)\s*(\{[^}]*?\})?(\||!\{[^}]*?\}|\s)*)/)
+			{
+				$outHash{halign} = $1;
+			}
 
-            $outCell = \%outHash;
-            $outRow[$j] = $outCell;
-        }
-        my $outRowRef = \@outRow;
-        $outArray[$i] = $outRowRef;
-    }
-    $outArrayRef = \@outArray;
-    return $outArrayRef;
+			$outCell = \%outHash;
+			$outRow[$j] = $outCell;
+		}
+		my $outRowRef = \@outRow;
+		$outArray[$i] = $outRowRef;
+	}
+	$outArrayRef = \@outArray;
+	return $outArrayRef;
 }
 
 sub ColumnCount {
-    my $optsRef      = shift;
-    my @options      = @$optsRef;
-    my $lastRowIndex = $#options;
-    my $colCount     = 0;
-    for my $i ( 0 .. $lastRowIndex ) {
-        my $rowOptsRef      = $options[$i];
-        my @rowOpts         = @$rowOptsRef;
-        my $lastColIndex    = $#rowOpts;
-        my $thisRowColCount = 0;
-        for my $j ( 0 .. $lastColIndex ) {
-            $thisRowColCount += $rowOpts[$j]->{colspan};
-        }
-        $colCount = max( $colCount, $thisRowColCount );
-    }
-    return $colCount;
+	my $optsRef      = shift;
+	my @options      = @$optsRef;
+	my $lastRowIndex = $#options;
+	my $colCount     = 0;
+	for my $i (0 .. $lastRowIndex) {
+		my $rowOptsRef      = $options[$i];
+		my @rowOpts         = @$rowOptsRef;
+		my $lastColIndex    = $#rowOpts;
+		my $thisRowColCount = 0;
+		for my $j (0 .. $lastColIndex) {
+			$thisRowColCount += $rowOpts[$j]->{colspan};
+		}
+		$colCount = max($colCount, $thisRowColCount);
+	}
+	return $colCount;
 }
 
 sub TableOptions {
-    my $colCount         = shift;
-    my %supportedOptions = (
-        center          => 1,
-        caption         => '',
-        horizontalrules => 0,
-        texalignment    => join( '', ('c') x $colCount ),
-        Xratio          => 0.97,
-        encase          => [ '', '' ],
-        rowheaders      => 0,
-        tablecss        => '',
-        captioncss      => '',
-        columnscss      => [ ('') x $colCount ],
-        datacss         => '',
-        headercss       => '',
-        allcellcss      => '',
-        valign          => 'top',
-        LaYoUt          => 0,
-    );
-    %outHash = %supportedOptions;
-    my %userOptions = @_;
-    for my $key ( keys(%supportedOptions) ) {
-        $outHash{$key} = $userOptions{$key} if defined( $userOptions{$key} );
-    }
+	my $colCount         = shift;
+	my %supportedOptions = (
+		center          => 1,
+		caption         => '',
+		horizontalrules => 0,
+		texalignment    => join('', ('c') x $colCount),
+		Xratio          => 0.97,
+		encase          => [ '', '' ],
+		rowheaders      => 0,
+		tablecss        => '',
+		captioncss      => '',
+		columnscss      => [ ('') x $colCount ],
+		datacss         => '',
+		headercss       => '',
+		allcellcss      => '',
+		valign          => 'top',
+		LaYoUt          => 0,
+	);
+	%outHash = %supportedOptions;
+	my %userOptions = @_;
+	for my $key (keys(%supportedOptions)) {
+		$outHash{$key} = $userOptions{$key} if defined($userOptions{$key});
+	}
 
-    # special user shortcut
-    $outHash{texalignment} = $userOptions{align}
-      if ( defined( $userOptions{align} ) && !$userOptions{texalignment} );
+	# special user shortcut
+	$outHash{texalignment} = $userOptions{align}
+		if (defined($userOptions{align}) && !$userOptions{texalignment});
 
-    # legacy misnomers
-    $outHash{horizontalrules} = $userOptions{midrules}
-      if ( defined( $userOptions{midrules} ) && !$outHash{horizontalrules} );
-    return \%outHash;
+	# legacy misnomers
+	$outHash{horizontalrules} = $userOptions{midrules}
+		if (defined($userOptions{midrules}) && !$outHash{horizontalrules});
+	return \%outHash;
 }
 
 sub ParseAlignment {
-    my $alignment = shift;
+	my $alignment = shift;
 
-    # first we parse things like *{20}{...} to expand them
-    my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;
-    while ( $alignment =~ /$pattern/ ) {
-        my @captured    = ( $alignment =~ /$pattern/ );
-        my $replaceWith = $captured[1] x $captured[0];
-        $alignment =~ s/$pattern/$replaceWith/;
-    }
+	# first we parse things like *{20}{...} to expand them
+	my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;
+	while ($alignment =~ /$pattern/) {
+		my @captured    = ($alignment =~ /$pattern/);
+		my $replaceWith = $captured[1] x $captured[0];
+		$alignment =~ s/$pattern/$replaceWith/;
+	}
 
-    my @align = ();
+	my @align = ();
 
-    # 0th entry is only for possible left border
-    # other entries have only right borders,
-    # the actual alignment is r, c, l, X, or p
-    # explicit width vertical rules from !{...}
-    # latex directives from >{...}
-    # we make an array of the tokens of type:
-    # r, c, l, X, |, !{...}, p{...}, >{...}
-    # this is complicated because of potential nested brackets
-    my @tokens             = ();
-    my $bracesregex        = qr/(\{(?>[^{}]|(?R))*\})/x;
-    my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
+	# 0th entry is only for possible left border
+	# other entries have only right borders,
+	# the actual alignment is r, c, l, X, or p
+	# explicit width vertical rules from !{...}
+	# latex directives from >{...}
+	# we make an array of the tokens of type:
+	# r, c, l, X, |, !{...}, p{...}, >{...}
+	# this is complicated because of potential nested brackets
+	my @tokens             = ();
+	my $bracesregex        = qr/(\{(?>[^{}]|(?R))*\})/x;
+	my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
 
-  # . at the end is to ensure we are whittling down $alignment at least a little
-    my $tokenspattern =
-      qr/^([rclX\|]\s*|[!p>]\s*\{((??{$bracecontentsregex}))\}\s*|.)/;
+	# . at the end is to ensure we are whittling down $alignment at least a little
+	my $tokenspattern = qr/^([rclX\|]\s*|[!p>]\s*\{((??{$bracecontentsregex}))\}\s*|.)/;
 
-    $align[0] = { left => 0 };
-    $leftpattern = '^\s*(\|\s*|!\s*\{\s*\\vrule\s+width\s+([^}]*?)\})';
-    while ( $alignment =~ /$leftpattern/ ) {
-        my $token = $1;
-        if ( $token =~ /^\|/ ) {
+	$align[0] = { left => 0 };
+	$leftpattern = '^\s*(\|\s*|!\s*\{\s*\\vrule\s+width\s+([^}]*?)\})';
+	while ($alignment =~ /$leftpattern/) {
+		my $token = $1;
+		if ($token =~ /^\|/) {
 
-            # this counts how many | we have
-            $align[0]->{left} = 0
-              unless ( $align[$i]->{left} && $align[$i]->{left} =~ /\d+/ );
-            $align[0]->{left} += 1;
-        }
-        elsif ( $token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/ ) {
-            $align[0]->{left} = $1;
-        }
-        $alignment =~ s/$leftpattern//;
-    }
+			# this counts how many | we have
+			$align[0]->{left} = 0
+				unless ($align[$i]->{left} && $align[$i]->{left} =~ /\d+/);
+			$align[0]->{left} += 1;
+		} elsif ($token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/) {
+			$align[0]->{left} = $1;
+		}
+		$alignment =~ s/$leftpattern//;
+	}
 
-# now that leftmost vertical rule tokens taken care of, get all the other tokens
-    while ($alignment) {
-        my $token = ( $alignment =~ /$tokenspattern/ )[0];
-        $alignment =~ s/$tokenspattern//;
-        push( @tokens, $token );
-    }
+	# now that leftmost vertical rule tokens taken care of, get all the other tokens
+	while ($alignment) {
+		my $token = ($alignment =~ /$tokenspattern/)[0];
+		$alignment =~ s/$tokenspattern//;
+		push(@tokens, $token);
+	}
 
-    # now run through tokens and grow @align
-    # index for @align
-    my $i = 1;
+	# now run through tokens and grow @align
+	# index for @align
+	my $i = 1;
 
-    # $j is index for @tokens
-    for my $j ( 0 .. $#tokens ) {
-        my $token = $tokens[$j];
-        my $next  = $tokens[ $j + 1 ] // '';
-        if ( $token =~ /^([lcrX])/ ) {
-            $align[$i]->{halign} = $1;
-            $align[$i]->{valign} = 'top' if ( $1 eq 'X' );
-            $i++ unless ( $next =~ /^[|!]/ );
-        }
-        elsif ( $token =~ /^\|/ ) {
+	# $j is index for @tokens
+	for my $j (0 .. $#tokens) {
+		my $token = $tokens[$j];
+		my $next  = $tokens[ $j + 1 ] // '';
+		if ($token =~ /^([lcrX])/) {
+			$align[$i]->{halign} = $1;
+			$align[$i]->{valign} = 'top' if ($1 eq 'X');
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^\|/) {
 
-            # this counts how many | we have
-            $align[$i]->{right} = 0
-              unless ( $align[$i]->{right} && $align[$i]->{right} =~ /\d+/ );
-            $align[$i]->{right} += 1;
-            $i++ unless ( $next =~ /^[|!]/ );
-        }
-        elsif ( $token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/ ) {
+			# this counts how many | we have
+			$align[$i]->{right} = 0
+				unless ($align[$i]->{right} && $align[$i]->{right} =~ /\d+/);
+			$align[$i]->{right} += 1;
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/) {
 
-# for this style of vertical rule we store the width instead of a small positive integer
-            $align[$i]->{right} = $1;
-            $i++ unless ( $next =~ /^[|!]/ );
-        }
-        elsif ( $token =~ /^p\{((??{$bracecontentsregex}))\}\s*/ ) {
-            $align[$i]->{halign} = 'l';
+			# for this style of vertical rule we store the width instead of a small positive integer
+			$align[$i]->{right} = $1;
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^p\{((??{$bracecontentsregex}))\}\s*/) {
+			$align[$i]->{halign} = 'l';
 
-            # record top alignment, but could be overwritten by row valign
-            $align[$i]->{valign} = 'top';
-            $align[$i]->{width}  = $1;
-            $i++ unless ( $next =~ /^[|!]/ );
-        }
-        elsif ( $token =~ /^>\s*\{((??{$bracecontentsregex}))\}/ ) {
-            $align[$i]->{tex} = $1;
+			# record top alignment, but could be overwritten by row valign
+			$align[$i]->{valign} = 'top';
+			$align[$i]->{width}  = $1;
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^>\s*\{((??{$bracecontentsregex}))\}/) {
+			$align[$i]->{tex} = $1;
 
-            # could parse these further for color identification, etc
-        }
-    }
+			# could parse these further for color identification, etc
+		}
+	}
 
-    return \@align;
+	return \@align;
 
 }
 
 sub latexEnvironment {
-    my ( $inside, $environment, $options, $separator ) = @_;
-    $separator = "\n" unless ($separator);
-    my $return = "\\begin{$environment}";
-    for my $x (@$options) {
-        $return .= "{$x}" if ( $x ne '' );
-    }
-    $return .= "$separator$inside$separator";
-    $return .= "\\end{$environment}";
-    return $return;
+	my ($inside, $environment, $options, $separator) = @_;
+	$separator = "\n" unless ($separator);
+	my $return = "\\begin{$environment}";
+	for my $x (@$options) {
+		$return .= "{$x}" if ($x ne '');
+	}
+	$return .= "$separator$inside$separator";
+	$return .= "\\end{$environment}";
+	return $return;
 }
 
 sub latexCommand {
-    my ( $command, $arguments ) = @_;
-    my $return = "\\$command";
-    for my $x (@$arguments) {
-        $return .= "{$x}" if ( $x ne '' );
-    }
-    $return .= " ";
-    return $return;
+	my ($command, $arguments) = @_;
+	my $return = "\\$command";
+	for my $x (@$arguments) {
+		$return .= "{$x}" if ($x ne '');
+	}
+	$return .= " ";
+	return $return;
 }
 
 sub wrap {
-    my ( $center, $left, $right, $separator ) = @_;
-    $separator = "\n" unless ($separator);
-    return $center                   unless ( $left || $right );
-    return "$left$separator$center"  unless $right;
-    return "$center$separator$right" unless $left;
-    return "$left$separator$center$separator$right";
+	my ($center, $left, $right, $separator) = @_;
+	$separator = "\n" unless ($separator);
+	return $center                   unless ($left || $right);
+	return "$left$separator$center"  unless $right;
+	return "$center$separator$right" unless $left;
+	return "$left$separator$center$separator$right";
 }
 
 sub prefix {
-    my ( $center, $left, $separator ) = @_;
-    $separator = "\n" unless ($separator);
-    return join( "$separator", ( $left, $center ) ) if ( $left ne '' );
-    return $center;
+	my ($center, $left, $separator) = @_;
+	$separator = "\n" unless ($separator);
+	return join("$separator", ($left, $center)) if ($left ne '');
+	return $center;
 }
 
 sub suffix {
-    my ( $center, $right, $separator ) = @_;
-    $separator = "\n" unless ($separator);
-    return join( "$separator", ( $center, $right ) ) if ( $right ne '' );
-    return $center;
+	my ($center, $right, $separator) = @_;
+	$separator = "\n" unless ($separator);
+	return join("$separator", ($center, $right)) if ($right ne '');
+	return $center;
 }
 
 sub css {
-    my ( $property, $value ) = @_;
-    return ($value) ? "$property:$value;" : '';
+	my ($property, $value) = @_;
+	return ($value) ? "$property:$value;" : '';
 }
 
 sub tag {
-    my ( $inner, $name, $attributes ) = @_;
-    my $return = "<$name";
-    for my $x ( lex_sort( keys %$attributes ) ) {
-        $return .= qq( $x="$attributes->{$x}") if ( $attributes->{$x} ne '' );
-    }
-    if ($inner) {
-        $return .= ">\n";
-        $return .= $inner;
-        $return .= "\n</$name>";
-    }
-    else {
-        $return .= '>' unless ( $main::displayMode eq 'PTX' );
-        $return .= '/>' if ( $main::displayMode eq 'PTX' );
-    }
-    return $return;
+	my ($inner, $name, $attributes) = @_;
+	my $return = "<$name";
+	for my $x (lex_sort(keys %$attributes)) {
+		$return .= qq( $x="$attributes->{$x}") if ($attributes->{$x} ne '');
+	}
+	if ($inner) {
+		$return .= ">\n";
+		$return .= $inner;
+		$return .= "\n</$name>";
+	} else {
+		$return .= '>' unless ($main::displayMode eq 'PTX');
+		$return .= '/>' if ($main::displayMode eq 'PTX');
+	}
+	return $return;
 }
 
 sub getRuleCSS {
-    my $input  = shift;
-    my $output = '';
-    if ( $input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/ ) {
-        $output = "solid $1px" if $1;
-    }
-    elsif ($input) {
-        $output = "solid $input" if $input;
-    }
-    return $output;
+	my $input  = shift;
+	my $output = '';
+	if ($input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/) {
+		$output = "solid $1px" if $1;
+	} elsif ($input) {
+		$output = "solid $input" if $input;
+	}
+	return $output;
 }
 
 sub getPTXthickness {
-    my $input  = shift;
-    my $output = '';
-    if ( $input == 1 ) {
-        $output = "minor";
-    }
-    elsif ( $input == 2 ) {
-        $output = "medium";
-    }
-    elsif ( $input >= 3 ) {
-        $output = "major";
-    }
-    elsif ( $input eq '0.04em' ) {
-        $output = 'minor';
-    }
-    elsif ( $input eq '0.07em' ) {
-        $output = 'medium';
-    }
-    elsif ( $input eq '0.11em' ) {
-        $output = 'major';
-    }
-    elsif ($input) {
-        $output = "minor";
-    }
-    return $output;
+	my $input  = shift;
+	my $output = '';
+	if ($input == 1) {
+		$output = "minor";
+	} elsif ($input == 2) {
+		$output = "medium";
+	} elsif ($input >= 3) {
+		$output = "major";
+	} elsif ($input eq '0.04em') {
+		$output = 'minor';
+	} elsif ($input eq '0.07em') {
+		$output = 'medium';
+	} elsif ($input eq '0.11em') {
+		$output = 'major';
+	} elsif ($input) {
+		$output = "minor";
+	}
+	return $output;
 }
 
 sub getWidthPercent {
-    my $absWidth = shift;
-    my $x        = 0;
-    my $unit     = 'cm';
-    if ( $absWidth =~ /^(\.\d+|\d+\.?\d*)\s*(\w+)/ ) {
-        $x    = $1;
-        $unit = $2;
-    }
-    my %convert_to_cm = (
-        'pt' => 1 / 864 * 249 / 250 * 12 * 2.54,
-        'mm' => 1 / 10,
-        'cm' => 1,
-        'in' => 2.54,
-        'ex' => 0.15132,
-        'em' => 0.35146,
-        'mu' => 0.35146 / 8,
-        'sp' => 1 / 864 * 249 / 250 * 12 * 2.54 / 65536,
-        'bp' => 2.54 / 72,
-        'dd' => 1 / 864 * 249 / 250 * 12 * 2.54 * 1238 / 1157,
-        'pc' => 1 / 864 * 249 / 250 * 12 * 2.54 * 12,
-        'cc' => 1 / 864 * 249 / 250 * 12 * 2.54 * 1238 / 1157 * 12,
-        'px' => 2.54 / 72,
-    );
-    return ( int( $x * $convert_to_cm{$unit} / ( 6.25 * 2.54 ) * 10000 ) / 100 )
-      . '%';
+	my $absWidth = shift;
+	my $x        = 0;
+	my $unit     = 'cm';
+	if ($absWidth =~ /^(\.\d+|\d+\.?\d*)\s*(\w+)/) {
+		$x    = $1;
+		$unit = $2;
+	}
+	my %convert_to_cm = (
+		'pt' => 1 / 864 * 249 / 250 * 12 * 2.54,
+		'mm' => 1 / 10,
+		'cm' => 1,
+		'in' => 2.54,
+		'ex' => 0.15132,
+		'em' => 0.35146,
+		'mu' => 0.35146 / 8,
+		'sp' => 1 / 864 * 249 / 250 * 12 * 2.54 / 65536,
+		'bp' => 2.54 / 72,
+		'dd' => 1 / 864 * 249 / 250 * 12 * 2.54 * 1238 / 1157,
+		'pc' => 1 / 864 * 249 / 250 * 12 * 2.54 * 12,
+		'cc' => 1 / 864 * 249 / 250 * 12 * 2.54 * 1238 / 1157 * 12,
+		'px' => 2.54 / 72,
+	);
+	return (int($x * $convert_to_cm{$unit} / (6.25 * 2.54) * 10000) / 100) . '%';
 }
 
 1;

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -1,3 +1,4 @@
+
 =head1 niceTables.pl
 
 
@@ -169,20 +170,21 @@ Options for ROWS
 
 =cut
 
-sub _niceTables_init {}; # don't reload this file
+sub _niceTables_init { };    # don't reload this file
 
 sub DataTable {
-	my $userArray = shift;
-	my $dataArray = DataArray($userArray);
-	my $optsArray = OptionsArray($userArray);
-	my $colCount = ColumnCount($optsArray);
-	my $tableOpts = TableOptions($colCount, @_);
-	my $alignment = ParseAlignment($tableOpts->{texalignment});
-	TableEnvironment($dataArray, $optsArray, $colCount, $tableOpts, $alignment);
+    my $userArray = shift;
+    my $dataArray = DataArray($userArray);
+    my $optsArray = OptionsArray($userArray);
+    my $colCount  = ColumnCount($optsArray);
+    my $tableOpts = TableOptions( $colCount, @_ );
+    my $alignment = ParseAlignment( $tableOpts->{texalignment} );
+    TableEnvironment( $dataArray, $optsArray, $colCount, $tableOpts,
+        $alignment );
 }
 
 sub LayoutTable {
-	return DataTable(@_, LaYoUt => 1); 
+    return DataTable( @_, LaYoUt => 1 );
 }
 
 # Make the outer table enovornment
@@ -192,773 +194,960 @@ sub LayoutTable {
 # encase, rowheaders should be passed to cells
 # various css should be self-explanatory
 sub TableEnvironment {
-	my ($dataArray, $optsArray, $colCount, $tableOpts, $alignment) = @_;
-	my @alignment = @$alignment;
+    my ( $dataArray, $optsArray, $colCount, $tableOpts, $alignment ) = @_;
+    my @alignment = @$alignment;
 
-	# determine if somewhere in the overall alignment, there are X columns
-	my $hasX = 0;
-	for my $align (@alignment) {
-		if ($align->{halign} eq 'X') {
-			$hasX = 1;
-			last;
-		}
-	}
+    # determine if somewhere in the overall alignment, there are X columns
+    my $hasX = 0;
+    for my $align (@alignment) {
+        if ( $align->{halign} eq 'X' ) {
+            $hasX = 1;
+            last;
+        }
+    }
 
-	# determine if first row has top
-	my $top;
-	for my $x (@{$optsArray->[0]}) {
-		$top = $x->{top} if ($x->{top});
-	}
+    # determine if first row has top
+    my $top;
+    for my $x ( @{ $optsArray->[0] } ) {
+        $top = $x->{top} if ( $x->{top} );
+    }
 
-	# get cols (only has some formatting specifications) and rows (the actual content)
-	my $cols = Cols($alignment, $tableOpts, $optsArray);
-	my $rows = Rows($dataArray, $optsArray, $colCount, $tableOpts, $alignment);
+# get cols (only has some formatting specifications) and rows (the actual content)
+    my $cols = Cols( $alignment, $tableOpts, $optsArray );
+    my $rows =
+      Rows( $dataArray, $optsArray, $colCount, $tableOpts, $alignment );
 
-	# TeX
-	my $tex = $rows;
-	my $tabulartype = $hasX ? 'tabularx' : 'tabular';
-	my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
-	$tex = latexEnvironment($tex, $tabulartype, [$tabularwidth, $tableOpts->{texalignment}], ' ');
-	$tex = prefix($tex, '\centering') if $tableOpts->{center}; 
-	$tex = suffix($tex, "\\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\\captionof*{table}{$tableOpts->{caption}}") if ($tableOpts->{caption});
-	$tex = latexEnvironment($tex, 'minipage', ['\linewidth']);
-	$tex = wrap($tex, '\par', '\par\vspace{1pc}');
+    # TeX
+    my $tex          = $rows;
+    my $tabulartype  = $hasX ? 'tabularx'                        : 'tabular';
+    my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
+    $tex = latexEnvironment( $tex, $tabulartype,
+        [ $tabularwidth, $tableOpts->{texalignment} ], ' ' );
+    $tex = prefix( $tex, '\centering' ) if $tableOpts->{center};
+    $tex = suffix( $tex,
+"\\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\\captionof*{table}{$tableOpts->{caption}}"
+    ) if ( $tableOpts->{caption} );
+    $tex = latexEnvironment( $tex, 'minipage', ['\linewidth'] );
+    $tex = wrap( $tex, '\par', '\par\vspace{1pc}' );
 
-	# HTML
-	my $css = $tableOpts->{tablecss};
-	if ($hasX) {
-		$css .= css('width', $tableOpts->{Xratio}*100 . '%');
-	}	
-	$css .= css('border-left', getRuleCSS($alignment[0]->{left}));
-	$css .= css('margin', 'auto') if $tableOpts->{center};
+    # HTML
+    my $css = $tableOpts->{tablecss};
+    if ($hasX) {
+        $css .= css( 'width', $tableOpts->{Xratio} * 100 . '%' );
+    }
+    $css .= css( 'border-left', getRuleCSS( $alignment[0]->{left} ) );
+    $css .= css( 'margin',      'auto' ) if $tableOpts->{center};
 
-	my $html = $rows;
-	my $htmlcols = '';
-	$htmlcols = tag($cols, 'colgroup') unless ($cols =~ /^(<col>|\n)*$/ or $tableOpts->{LaYoUt});
-	$html = prefix($html, $htmlcols);
-	my $htmlcaption = tag($tableOpts->{caption}, 'caption', {style => $tableOpts->{captioncss}});
-	$html = prefix($html, $htmlcaption) unless $tableOpts->{LaYoUt};
-	if ($tableOpts->{LaYoUt}) {
-		$css .= css('display', 'table');
-		$css .= css('border-collapse', 'collapse');
-		$html = tag($html, 'div', {style => $css});
-	} else {
-		$html = tag($html, 'table', {style => $css});
-	}
+    my $html     = $rows;
+    my $htmlcols = '';
+    $htmlcols = tag( $cols, 'colgroup' )
+      unless ( $cols =~ /^(<col>|\n)*$/ or $tableOpts->{LaYoUt} );
+    $html = prefix( $html, $htmlcols );
+    my $htmlcaption = tag( $tableOpts->{caption}, 'caption',
+        { style => $tableOpts->{captioncss} } );
+    $html = prefix( $html, $htmlcaption ) unless $tableOpts->{LaYoUt};
 
-	# PTX
-	my $ptx = $cols;
-	$ptx = prefix($rows, $cols);
-	my $ptxleft = getPTXthickness($alignment[0]->{left});
-	my $ptxtop = ($tableOpts->{horizontalrules}) ? 'major' : '';
-	$ptxtop = getPTXthickness($top) if $top;
-	my $ptxwidth;
-	my $ptxmargins;
-	if ($hasX) {
-		$ptxwidth = $tableOpts->{Xratio}*100;
-		my $leftmargin = ($tableOpts->{center}) ? (100 - $ptxwidth)/2 : 0;
-		my $rightmargin = 100 - $ptxwidth - $leftmargin;
-		$ptxmargins = "${leftmargin}% ${rightmargin}%";
-		$ptxwidth .= '%';
-	} elsif (!$tableOpts->{center}) {
-		$ptxwidth = '100%';
-		$ptxmargins = '0% 0%';
-	}
-	my $ptxbottom = ($tableOpts->{horizontalrules}) ? 'minor' : '';
-	$ptx = tag($ptx, 'tabular', {valign => $tableOpts->{valign}, width => $ptxwidth, margins => $ptxmargins, left => $ptxleft, top => $ptxtop, bottom => $ptxbottom});
-	# We fake a caption as a following tabular
-	my $ptxcaption = '';
-	if ($tableOpts->{caption}) {
-		$ptxcaption = $tableOpts->{caption};
-		$ptxcaption = tag($ptxcaption, 'cell');
-		$ptxcaption = tag($ptxcaption, 'row');
-		my $ptxcapwidth = '';
-		if ($hasX) {
-			$ptxcapwidth = $tableOpts->{Xratio}*100 . '%';
-		} else {
-			$ptxcapwidth = '50%';
-		}
-		$ptxcapcol = tag('', 'col', {width => $ptxcapwidth});
-		$ptxcaption = prefix($ptxcaption, $ptxcapcol);
-		$ptxcaption = tag($ptxcaption, 'tabular', {width => $ptxwidth, margins => $ptxmargins});
-	}
-	$ptx = suffix($ptx, $ptxcaption);
+    if ( $tableOpts->{LaYoUt} ) {
+        $css .= css( 'display',         'table' );
+        $css .= css( 'border-collapse', 'collapse' );
+        $html = tag( $html, 'div', { style => $css } );
+    }
+    else {
+        $html = tag( $html, 'table', { style => $css } );
+    }
 
-	MODES(
-		TeX => $tex,
-		HTML => $html,
-		PTX => $ptx,
-	);
+    # PTX
+    my $ptx = $cols;
+    $ptx = prefix( $rows, $cols );
+    my $ptxleft = getPTXthickness( $alignment[0]->{left} );
+    my $ptxtop  = ( $tableOpts->{horizontalrules} ) ? 'major' : '';
+    $ptxtop = getPTXthickness($top) if $top;
+    my $ptxwidth;
+    my $ptxmargins;
+
+    if ($hasX) {
+        $ptxwidth = $tableOpts->{Xratio} * 100;
+        my $leftmargin = ( $tableOpts->{center} ) ? ( 100 - $ptxwidth ) / 2 : 0;
+        my $rightmargin = 100 - $ptxwidth - $leftmargin;
+        $ptxmargins = "${leftmargin}% ${rightmargin}%";
+        $ptxwidth .= '%';
+    }
+    elsif ( !$tableOpts->{center} ) {
+        $ptxwidth   = '100%';
+        $ptxmargins = '0% 0%';
+    }
+    my $ptxbottom = ( $tableOpts->{horizontalrules} ) ? 'minor' : '';
+    $ptx = tag(
+        $ptx,
+        'tabular',
+        {
+            valign  => $tableOpts->{valign},
+            width   => $ptxwidth,
+            margins => $ptxmargins,
+            left    => $ptxleft,
+            top     => $ptxtop,
+            bottom  => $ptxbottom
+        }
+    );
+
+    # We fake a caption as a following tabular
+    my $ptxcaption = '';
+    if ( $tableOpts->{caption} ) {
+        $ptxcaption = $tableOpts->{caption};
+        $ptxcaption = tag( $ptxcaption, 'cell' );
+        $ptxcaption = tag( $ptxcaption, 'row' );
+        my $ptxcapwidth = '';
+        if ($hasX) {
+            $ptxcapwidth = $tableOpts->{Xratio} * 100 . '%';
+        }
+        else {
+            $ptxcapwidth = '50%';
+        }
+        $ptxcapcol  = tag( '', 'col', { width => $ptxcapwidth } );
+        $ptxcaption = prefix( $ptxcaption, $ptxcapcol );
+        $ptxcaption = tag( $ptxcaption, 'tabular',
+            { width => $ptxwidth, margins => $ptxmargins } );
+    }
+    $ptx = suffix( $ptx, $ptxcaption );
+
+    MODES(
+        TeX  => $tex,
+        HTML => $html,
+        PTX  => $ptx,
+    );
 
 }
 
-
 sub Cols {
-	my ($alignment, $tableOpts, $optsArray) = @_;
-	my $columnscss = $tableOpts->{columnscss};
-	my @html;
-	my @ptx;
-	my @alignment = @$alignment;
-	my $leftend = shift(@alignment);
+    my ( $alignment, $tableOpts, $optsArray ) = @_;
+    my $columnscss = $tableOpts->{columnscss};
+    my @html;
+    my @ptx;
+    my @alignment = @$alignment;
+    my $leftend   = shift(@alignment);
 
-	for my $i (0..$#alignment) {
-		my $align = $alignment[$i];
-		# determine if this column has paragraph cells
-		my $width = '';
-		for my $y (@$optsArray) {
-			if ($y->[$i]->{halign} =~ /^p\{([^}]*?)\}/) {
-				$width = $1;
-			};
-		}
+    for my $i ( 0 .. $#alignment ) {
+        my $align = $alignment[$i];
 
-		# HTML
-		my $htmlright = '';
-		$htmlright .= css('border-right', 'solid 2px') if ($tableOpts->{rowheaders} && $i == 0);
-		$htmlright .= css('border-right', getRuleCSS($align->{right}));
+        # determine if this column has paragraph cells
+        my $width = '';
+        for my $y (@$optsArray) {
+            if ( $y->[$i]->{halign} =~ /^p\{([^}]*?)\}/ ) {
+                $width = $1;
+            }
+        }
 
-		$htmlcolcss = $columnscss->[$i];
-		if ($align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
-			$htmlcolcss .= css('background-color', ($1 ? '#' : '') . $2);
-		}
+        # HTML
+        my $htmlright = '';
+        $htmlright .= css( 'border-right', 'solid 2px' )
+          if ( $tableOpts->{rowheaders} && $i == 0 );
+        $htmlright .= css( 'border-right', getRuleCSS( $align->{right} ) );
 
-		my $html = tag('', 'col', {style => "${htmlright}${htmlcolcss}"});
-		push(@html, $html);
+        $htmlcolcss = $columnscss->[$i];
+        if ( $align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/ ) {
+            $htmlcolcss .= css( 'background-color', ( $1 ? '#' : '' ) . $2 );
+        }
 
-		# PTX
-		my $ptxhalign = '';
-		$ptxhalign = 'center' if ($align->{halign} eq 'c');
-		$ptxhalign = 'right' if ($align->{halign} eq 'r');
-		my $ptxright = '';
-		$ptxright = getPTXthickness($align->{right});
-		my $ptxwidth = '';
-		$ptxwidth = getWidthPercent($align->{width}) if $align->{width};
-		$ptxwidth = ($tableOpts->{Xratio} / ($#alignment + 1) * 100) . '%' if ($align->{halign} eq 'X');
-		$ptxwidth = getWidthPercent($width) if $width;
-		my $ptx = tag('', 'col', {header => ($tableOpts->{rowheaders} && $i == 0) ? 'yes' : '', halign => $ptxhalign, right => $ptxright, width => $ptxwidth});
-		push(@ptx, $ptx);
-	}
+        my $html = tag( '', 'col', { style => "${htmlright}${htmlcolcss}" } );
+        push( @html, $html );
 
-	$return = MODES(
-		HTML => join("\n", @html),
-		PTX => join("\n", @ptx)
-	);
+        # PTX
+        my $ptxhalign = '';
+        $ptxhalign = 'center' if ( $align->{halign} eq 'c' );
+        $ptxhalign = 'right'  if ( $align->{halign} eq 'r' );
+        my $ptxright = '';
+        $ptxright = getPTXthickness( $align->{right} );
+        my $ptxwidth = '';
+        $ptxwidth = getWidthPercent( $align->{width} ) if $align->{width};
+        $ptxwidth = ( $tableOpts->{Xratio} / ( $#alignment + 1 ) * 100 ) . '%'
+          if ( $align->{halign} eq 'X' );
+        $ptxwidth = getWidthPercent($width) if $width;
+        my $ptx = tag(
+            '', 'col',
+            {
+                header => ( $tableOpts->{rowheaders} && $i == 0 ) ? 'yes' : '',
+                halign => $ptxhalign,
+                right  => $ptxright,
+                width  => $ptxwidth
+            }
+        );
+        push( @ptx, $ptx );
+    }
 
-	return $return;
+    $return = MODES(
+        HTML => join( "\n", @html ),
+        PTX  => join( "\n", @ptx )
+    );
+
+    return $return;
 
 }
 
 sub Rows {
-	my ($dataArray, $optsArray, $colCount, $tableOpts, $alignment) = @_;
-	my @data = @$dataArray;
-	
-	my @tex;
-	my @htmlhead;
-	my @htmlbody;
-	my $stillinhtmlhead = 1;
-	my @ptx;
-	for my $i (0..$#data) {
-		my $rowData = $data[$i];
-		my $rowOpts = $optsArray->[$i];
-		my $row = Row($rowData, $rowOpts, $tableOpts, $alignment);
-		# establish if this row has certain things
-		# non falsy last values are used
-		my $bottom = 0;
-		my $top = 0;
-		my $rowcolor = '';
-		my $headerrow = '';
-		my $valign = '';
-		for my $x (@$rowOpts) {
-			$bottom = $x->{bottom} if ($x->{bottom});
-			$top = $x->{top} if ($x->{top} && $i == 0);
-			$rowcolor = $x->{rowcolor} if ($x->{rowcolor});
-			$headerrow = 'yes' if ($x->{headerrow});
-			$valign = $x->{valign} if ($x->{valign});
-		}
+    my ( $dataArray, $optsArray, $colCount, $tableOpts, $alignment ) = @_;
+    my @data = @$dataArray;
 
-		# TeX
-		my $tex = $row;
-		# separator argument is space to avoid PGML catcode manipulation issues
-		$tex = prefix($tex, "\\rowcolor{$rowcolor}", ' ') if ($rowcolor =~ /^[^{]+$/);
-		$tex = prefix($tex, "\\rowcolor$rowcolor", ' ') if ($rowcolor =~ /^(\[HTML\])?\{[^}]+\}/);
-		$tex = prefix($tex, "\\toprule", ' ') if ($top || ($i == 0 && $tableOpts->{horizontalrules})); 
-		$tex = suffix($tex, "\\\\", ' ') unless ($i == $#data);
-		$tex = suffix($tex, "\\midrule", ' ') if ($i < $#data && ($bottom || $tableOpts->{horizontalrules}) || $headerrow);
-		$tex = suffix($tex, "\\\\\\bottomrule", ' ') if ($i == $#data && ($bottom or $tableOpts->{horizontalrules}));
-		push(@tex, $tex);
+    my @tex;
+    my @htmlhead;
+    my @htmlbody;
+    my $stillinhtmlhead = 1;
+    my @ptx;
+    for my $i ( 0 .. $#data ) {
+        my $rowData = $data[$i];
+        my $rowOpts = $optsArray->[$i];
+        my $row     = Row( $rowData, $rowOpts, $tableOpts, $alignment );
 
-		# HTML
-		my $css = '';
-		for my $x (@$rowOpts) {
-			$css .= $x->{rowcss} if  $x->{rowcss};
-		}
-		if ($rowcolor =~ /(\[HTML\])?{(.*?)[}!]/) {
-			$css .= css('background-color', ($1 ? '#' : '') . $2);
-		} else {
-			$css .= css('background-color', $rowcolor) if $rowcolor;
-		}
-		$css .= css('border-top', 'solid 3px') if ($i == 0 && $tableOpts->{horizontalrules});
-		$css .= css('border-top', getRuleCSS($top));
-		$css .= css('border-bottom', 'solid 1px') if ($i < $#data && $tableOpts->{horizontalrules});
-		$css .= css('border-bottom', 'solid 3px') if ($i == $#data && $tableOpts->{horizontalrules});
-		$css .= css('border-bottom', getRuleCSS($bottom));
-		$css .= css('vertical-align', $valign);
-		my $html;
-		if ($tableOpts->{LaYoUt}) {
-			$css .= css('display', 'table-row');
-			$html = tag($row, 'div', {style => $css});
-			push(@htmlbody, $html);
-		} else {
-			$html = tag($row, 'tr', {style => $css});
-			if ($stillinhtmlhead && $headerrow) {
-				push(@htmlhead, $html);
-			} else {
-				$stillinhtmlhead = 0;
-				push(@htmlbody, $html);
-			}
-		}
+        # establish if this row has certain things
+        # non falsy last values are used
+        my $bottom    = 0;
+        my $top       = 0;
+        my $rowcolor  = '';
+        my $headerrow = '';
+        my $valign    = '';
+        for my $x (@$rowOpts) {
+            $bottom    = $x->{bottom}   if ( $x->{bottom} );
+            $top       = $x->{top}      if ( $x->{top} && $i == 0 );
+            $rowcolor  = $x->{rowcolor} if ( $x->{rowcolor} );
+            $headerrow = 'yes'          if ( $x->{headerrow} );
+            $valign    = $x->{valign}   if ( $x->{valign} );
+        }
 
-		# PTX
-		my $ptx .= $row;
-		my $ptxbottom = '';
-		$ptxbottom = 'minor' if ($i < $#data && $tableOpts->{horizontalrules});
-		$ptxbottom = 'major' if ($i == $#data && $tableOpts->{horizontalrules});
-		$ptxbottom = getPTXthickness($bottom) if $bottom;
-		my $ptxleft = '';
-		$ptxleft = 'minor' if ($rowOpts->[0]->{halign} =~ /^\s*\|/);
-		$ptxleft = 'medium' if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|/);
-		$ptxleft = 'major' if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|\s*\|/);
-		if ($rowOpts->[0]->{halign} =~ /^(?:\s|\|)*!{\s*\\vrule\s+width\s+([^}]*?)\s*}/) {
-			$ptxleft = 'minor' if ($1);
-			$ptxleft = 'minor' if ($1 == '0.04em');
-			$ptxleft = 'medium' if ($1 == '0.07em');
-			$ptxleft = 'major' if ($1 == '0.11em');
-		};
-		$ptx = tag($ptx, 'row', {left => $ptxleft, valign => $valign, header => $headerrow, bottom => $ptxbottom});
-		push(@ptx, $ptx);
-	}
+        # TeX
+        my $tex = $row;
 
-	my $htmlout;
-	if ($tableOpts->{LaYoUt}) {
-		$htmlout = join("\n", @htmlbody)
-	} else {
-		my $htmlvalign = '';
-		$htmlvalign = $tableOpts->{valign} unless ($tableOpts->{valign} eq 'middle');
-		$htmlout = tag(join("\n", @htmlbody), 'tbody',  {style => css('vertical-align', $htmlvalign)});
-		$htmlout = prefix($htmlout, tag(join("\n", @htmlhead), 'thead', {style => css('vertical-align', $htmlvalign).css('border-bottom', 'solid 2px')})) if (@htmlhead);
-	}
-	
-	$return = MODES(
-		TeX => join(" ", @tex),
-		HTML => $htmlout,
-		PTX => join("\n", @ptx),
-	);
+        # separator argument is space to avoid PGML catcode manipulation issues
+        $tex = prefix( $tex, "\\rowcolor{$rowcolor}", ' ' )
+          if ( $rowcolor =~ /^[^{]+$/ );
+        $tex = prefix( $tex, "\\rowcolor$rowcolor", ' ' )
+          if ( $rowcolor =~ /^(\[HTML\])?\{[^}]+\}/ );
+        $tex = prefix( $tex, "\\toprule", ' ' )
+          if ( $top || ( $i == 0 && $tableOpts->{horizontalrules} ) );
+        $tex = suffix( $tex, "\\\\",      ' ' ) unless ( $i == $#data );
+        $tex = suffix( $tex, "\\midrule", ' ' )
+          if ( $i < $#data && ( $bottom || $tableOpts->{horizontalrules} )
+            || $headerrow );
+        $tex = suffix( $tex, "\\\\\\bottomrule", ' ' )
+          if ( $i == $#data && ( $bottom or $tableOpts->{horizontalrules} ) );
+        push( @tex, $tex );
 
-	return $return;
+        # HTML
+        my $css = '';
+        for my $x (@$rowOpts) {
+            $css .= $x->{rowcss} if $x->{rowcss};
+        }
+        if ( $rowcolor =~ /(\[HTML\])?{(.*?)[}!]/ ) {
+            $css .= css( 'background-color', ( $1 ? '#' : '' ) . $2 );
+        }
+        else {
+            $css .= css( 'background-color', $rowcolor ) if $rowcolor;
+        }
+        $css .= css( 'border-top', 'solid 3px' )
+          if ( $i == 0 && $tableOpts->{horizontalrules} );
+        $css .= css( 'border-top',    getRuleCSS($top) );
+        $css .= css( 'border-bottom', 'solid 1px' )
+          if ( $i < $#data && $tableOpts->{horizontalrules} );
+        $css .= css( 'border-bottom', 'solid 3px' )
+          if ( $i == $#data && $tableOpts->{horizontalrules} );
+        $css .= css( 'border-bottom',  getRuleCSS($bottom) );
+        $css .= css( 'vertical-align', $valign );
+        my $html;
+
+        if ( $tableOpts->{LaYoUt} ) {
+            $css .= css( 'display', 'table-row' );
+            $html = tag( $row, 'div', { style => $css } );
+            push( @htmlbody, $html );
+        }
+        else {
+            $html = tag( $row, 'tr', { style => $css } );
+            if ( $stillinhtmlhead && $headerrow ) {
+                push( @htmlhead, $html );
+            }
+            else {
+                $stillinhtmlhead = 0;
+                push( @htmlbody, $html );
+            }
+        }
+
+        # PTX
+        my $ptx .= $row;
+        my $ptxbottom = '';
+        $ptxbottom = 'minor'
+          if ( $i < $#data && $tableOpts->{horizontalrules} );
+        $ptxbottom = 'major'
+          if ( $i == $#data && $tableOpts->{horizontalrules} );
+        $ptxbottom = getPTXthickness($bottom) if $bottom;
+        my $ptxleft = '';
+        $ptxleft = 'minor'  if ( $rowOpts->[0]->{halign} =~ /^\s*\|/ );
+        $ptxleft = 'medium' if ( $rowOpts->[0]->{halign} =~ /^\s*\|\s*\|/ );
+        $ptxleft = 'major' if ( $rowOpts->[0]->{halign} =~ /^\s*\|\s*\|\s*\|/ );
+
+        if ( $rowOpts->[0]->{halign} =~
+            /^(?:\s|\|)*!{\s*\\vrule\s+width\s+([^}]*?)\s*}/ )
+        {
+            $ptxleft = 'minor'  if ($1);
+            $ptxleft = 'minor'  if ( $1 == '0.04em' );
+            $ptxleft = 'medium' if ( $1 == '0.07em' );
+            $ptxleft = 'major'  if ( $1 == '0.11em' );
+        }
+        $ptx = tag(
+            $ptx, 'row',
+            {
+                left   => $ptxleft,
+                valign => $valign,
+                header => $headerrow,
+                bottom => $ptxbottom
+            }
+        );
+        push( @ptx, $ptx );
+    }
+
+    my $htmlout;
+    if ( $tableOpts->{LaYoUt} ) {
+        $htmlout = join( "\n", @htmlbody );
+    }
+    else {
+        my $htmlvalign = '';
+        $htmlvalign = $tableOpts->{valign}
+          unless ( $tableOpts->{valign} eq 'middle' );
+        $htmlout = tag( join( "\n", @htmlbody ),
+            'tbody', { style => css( 'vertical-align', $htmlvalign ) } );
+        $htmlout = prefix(
+            $htmlout,
+            tag(
+                join( "\n", @htmlhead ),
+                'thead',
+                {
+                    style => css( 'vertical-align', $htmlvalign )
+                      . css( 'border-bottom', 'solid 2px' )
+                }
+            )
+        ) if (@htmlhead);
+    }
+
+    $return = MODES(
+        TeX  => join( " ", @tex ),
+        HTML => $htmlout,
+        PTX  => join( "\n", @ptx ),
+    );
+
+    return $return;
 
 }
 
 sub Row {
-	my ($rowData, $rowOpts, $tableOpts, $alignment) = @_;
-	my @alignment = @$alignment;
-	my $leftend = shift(@alignment);
-	my @data = @$rowData;
-	my $headerrow = '';
-	my $valign = '';
-	for my $x (@$rowOpts) {
-		$headerrow = 'yes' if ($x->{headerrow});
-		$valign = $x->{valign} if ($x->{valign});
-	}
+    my ( $rowData, $rowOpts, $tableOpts, $alignment ) = @_;
+    my @alignment = @$alignment;
+    my $leftend   = shift(@alignment);
+    my @data      = @$rowData;
+    my $headerrow = '';
+    my $valign    = '';
+    for my $x (@$rowOpts) {
+        $headerrow = 'yes'        if ( $x->{headerrow} );
+        $valign    = $x->{valign} if ( $x->{valign} );
+    }
 
-	my @tex;
-	my @html;
-	my @ptx;
-	for my $i (0..$#data) {
-		my $cellOpts = $rowOpts->[$i];
-		my $cell = $data[$i];
+    my @tex;
+    my @html;
+    my @ptx;
+    for my $i ( 0 .. $#data ) {
+        my $cellOpts = $rowOpts->[$i];
+        my $cell     = $data[$i];
 
-		# TeX
-		my $tex = $cell;
-		$tex = prefix($tex, $cellOpts->{tex});
-		$tex = wrap($tex, @{$tableOpts->{encase}}) unless $cellOpts->{noencase};
-		$tex = wrap($tex, $cellOpts->{texpre}, $cellOpts->{texpost});
-		$tex = prefix($tex, '\bfseries') if ($tableOpts->{rowheaders} and $i == 0 or $headerrow or $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i);
-		if ($cellOpts->{colspan} > 1 or $cellOpts->{halign} or $valign or ($tableOpts->{valign} && $tableOpts->{valign} ne 'top')) {
-			my $columntype = $cellOpts->{halign};
-			$columntype = $alignment[$i]->{halign} // 'l' unless $columntype;
-			$columntype = 'p{' . $tableOpts->{Xratio} / ($#data + 1) . "\\linewidth}" if ($columntype eq 'X');
-			$columntype = "p{$alignment[$i]->{width}}" if ($alignment[$i]->{width});
-			$columntype =~ s/^p/m/ if ($valign eq 'middle');
-			$columntype =~ s/^p/b/ if ($valign eq 'bottom');
-			$columntype =~ s/^p/m/ if ($tableOpts->{valign} eq 'middle');
-			$columntype =~ s/^p/b/ if ($tableOpts->{valign} eq 'bottom');
-			$tex = latexCommand('multicolumn', [$cellOpts->{colspan}, $columntype, $tex]);
-		}
-		$tex = suffix($tex, '&', ' ') unless ($i == $#data);
-		push(@tex, $tex);
+        # TeX
+        my $tex = $cell;
+        $tex = prefix( $tex, $cellOpts->{tex} );
+        $tex = wrap( $tex, @{ $tableOpts->{encase} } )
+          unless $cellOpts->{noencase};
+        $tex = wrap( $tex, $cellOpts->{texpre}, $cellOpts->{texpost} );
+        $tex = prefix( $tex, '\bfseries' )
+          if ( $tableOpts->{rowheaders} and $i == 0
+            or $headerrow
+            or $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i );
+        if (   $cellOpts->{colspan} > 1
+            or $cellOpts->{halign}
+            or $valign
+            or ( $tableOpts->{valign} && $tableOpts->{valign} ne 'top' ) )
+        {
+            my $columntype = $cellOpts->{halign};
+            $columntype = $alignment[$i]->{halign} // 'l' unless $columntype;
+            $columntype =
+              'p{' . $tableOpts->{Xratio} / ( $#data + 1 ) . "\\linewidth}"
+              if ( $columntype eq 'X' );
+            $columntype = "p{$alignment[$i]->{width}}"
+              if ( $alignment[$i]->{width} );
+            $columntype =~ s/^p/m/ if ( $valign eq 'middle' );
+            $columntype =~ s/^p/b/ if ( $valign eq 'bottom' );
+            $columntype =~ s/^p/m/ if ( $tableOpts->{valign} eq 'middle' );
+            $columntype =~ s/^p/b/ if ( $tableOpts->{valign} eq 'bottom' );
+            $tex = latexCommand( 'multicolumn',
+                [ $cellOpts->{colspan}, $columntype, $tex ] );
+        }
+        $tex = suffix( $tex, '&', ' ' ) unless ( $i == $#data );
+        push( @tex, $tex );
 
-		# HTML
-		my $t = 'td';
-		my $scope = '';
-		$t = 'th' and $scope = 'row' if ($i == 0 && $tableOpts->{rowheaders});
-		$t = 'th' and $scope = 'col' if ($headerrow);
-		$t = 'th' if ($cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i);
-		$scope = 'row' if ($cellOpts->{header} =~ /^(rh|row)$/i);
-		$scope = 'col' if ($cellOpts->{header} =~ /^(ch|col|column)$/i);
-		$t = 'td' and $scope = '' if ($cellOpts->{header} =~ /^td$/i);
-		my $css = '';
-		# col level
-		$css .= css('text-align', 'center') if ($alignment[$i]->{halign} eq 'c');
-		$css .= css('text-align', 'right') if ($alignment[$i]->{halign} eq 'r');
-		$css .= css('width', $alignment[$i]->{width}) if ($alignment[$i]->{width});
-		$css .= css('font-weight', 'bold') if ($alignment[$i]->{tex} =~ /\\bfseries/);
-		$css .= css('font-style', 'italic') if ($alignment[$i]->{tex} =~ /\\itshape/);
-		$css .= css('font-family', 'monospace') if ($alignment[$i]->{tex} =~ /\\ttfamily/);
-		if ($alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
-			$css .= css('color', ($1 ? '#' : '') . $2);
-		}
-		# cell level
-		$css .= $cellOpts->{cellcss};
-		if ($cellOpts->{halign} =~ /^([|\s]*\|)/ && $i == 0) {
-			my $count = $1 =~ tr/\|//;
-			$css .= css('border-left', "solid ${count}px");
-		}
-		if ($cellOpts->{halign} =~ /^(\s\|)*!{\\vrule\s+width\s+([^}]*?)}/ && $i == 0) {
-			$css .= css('border-left', "solid $2");
-		};
-		if ($cellOpts->{halign} =~ /(\|[|\s]*)$/) {
-			my $count = $1 =~ tr/\|//;
-			$css .= css('border-right', "solid ${count}px");
-		}
-		if ($cellOpts->{halign} =~ /!{\\vrule\s+width\s+([^}]*?)}\s*$/) {
-			$css .= css('border-right', "solid $1");
-		};
-		$css .= css('text-align', 'left') if ($cellOpts->{halign} =~ /^l/);
-		$css .= css('text-align', 'center') if ($cellOpts->{halign} =~ /^c/);
-		$css .= css('text-align', 'right') if ($cellOpts->{halign} =~ /^r/);
-		$css .= css('text-align', 'left') if ($cellOpts->{halign} =~ /^p/);
-		$css .= css('width', $1) if ($cellOpts->{halign} =~ /^p{([^}]*?)}/);
-		$css .= css('font-weight', 'bold') if ($cellOpts->{tex} =~ /\\bfseries/);
-		$css .= css('font-style', 'italic') if ($cellOpts->{tex} =~ /\\itshape/);
-		$css .= css('font-family', 'monospace') if ($cellOpts->{tex} =~ /\\ttfamily/);
-		if ($cellOpts->{tex} =~ /\\cellcolor(\[HTML\])?{(.*?)[}!]/) {
-			$css .= css('background-color', ($1 ? '#' : '') . $2);
-		}
-		if ($cellOpts->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
-			$css .= css('color', ($1 ? '#' : '') . $2);
-		}
-		$css .= $tableOpts->{allcellcss};
-		$css .= $tableOpts->{headercss} if ($t eq 'th');
-		$css .= $tableOpts->{datacss} if ($t eq 'td');
-		my $html = $cell;
-		$html = wrap($cell, @{$tableOpts->{encase}}) unless $cellOpts->{noencase};
-		if ($tableOpts->{LaYoUt}) {
-			$css .= css('display', 'table-cell');
-			my $cellvalign = $tableOpts->{valign};
-			$cellvalign = $valign if ($valign);
-			$css = css('vertical-align', $cellvalign) . $css;
-			$css = css('padding', '12pt') . $css;
-			if ($alignment[$i]->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
-				$css = css('background-color', ($1 ? '#' : '') . $2) . $css;
-			}
-			$css = css('border-right', getRuleCSS($alignment[$i]->{right})) . $css;
-			$html = tag($html, 'div', {style => $css});
-		} else {
-			$css = css('padding', '0pt 6pt') . $css;
-			$html = tag($html, $t, {style => $css, scope => $scope, colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : ''});
-		}
-		push(@html, $html);
+        # HTML
+        my $t     = 'td';
+        my $scope = '';
+        $t = 'th' and $scope = 'row' if ( $i == 0 && $tableOpts->{rowheaders} );
+        $t = 'th' and $scope = 'col' if ($headerrow);
+        $t = 'th' if ( $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i );
+        $scope = 'row' if ( $cellOpts->{header} =~ /^(rh|row)$/i );
+        $scope = 'col' if ( $cellOpts->{header} =~ /^(ch|col|column)$/i );
+        $t     = 'td' and $scope = '' if ( $cellOpts->{header} =~ /^td$/i );
+        my $css = '';
 
-		# PTX
-		my $ptx = $cell;
-		$ptx = wrap($ptx, @{$tableOpts->{encase}}) unless $cellOpts->{noencase};
-		# space following p is intentional hack to prevent p from scrubbing by PTX cleanup 
-		$ptx = wrap($ptx, '<p >', '</p >') if ($alignment[$i]->{width} or $alignment[$i]->{halign} eq 'X' or $cellOpts->{halign} =~ /^p/);
-		my $ptxhalign = '';
-		$ptxhalign = 'center' if ($cellOpts->{halign} =~ /c/);
-		$ptxhalign = 'right' if ($cellOpts->{halign} =~ /r/);
-		my $ptxright = '';
-		$ptxright = 'minor' if ($cellOpts->{halign} =~ /\|\s*$/);
-		$ptxright = 'medium' if ($cellOpts->{halign} =~ /\|\s*\|\s*$/);
-		$ptxright = 'major' if ($cellOpts->{halign} =~ /\|\s*\|\s*\|\s*$/);
-		if ($cellOpts->{halign} =~ /!{\s*\\vrule\s+width\s+([^}]*?)\s*}\s*$/) {
-			$ptxright = 'minor' if ($1);
-			$ptxright = 'minor' if ($1 == '0.04em');
-			$ptxright = 'medium' if ($1 == '0.07em');
-			$ptxright = 'major' if ($1 == '0.11em');
-		};
-		$ptx = tag($ptx, 'cell', {halign => $ptxhalign, colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : '', right => $ptxright});
-		push(@ptx, $ptx);
-	}
+        # col level
+        $css .= css( 'text-align', 'center' )
+          if ( $alignment[$i]->{halign} eq 'c' );
+        $css .= css( 'text-align', 'right' )
+          if ( $alignment[$i]->{halign} eq 'r' );
+        $css .= css( 'width', $alignment[$i]->{width} )
+          if ( $alignment[$i]->{width} );
+        $css .= css( 'font-weight', 'bold' )
+          if ( $alignment[$i]->{tex} =~ /\\bfseries/ );
+        $css .= css( 'font-style', 'italic' )
+          if ( $alignment[$i]->{tex} =~ /\\itshape/ );
+        $css .= css( 'font-family', 'monospace' )
+          if ( $alignment[$i]->{tex} =~ /\\ttfamily/ );
+        if ( $alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/ ) {
+            $css .= css( 'color', ( $1 ? '#' : '' ) . $2 );
+        }
 
-	$return = MODES(
-		TeX => join(" ", @tex),
-		HTML => join("\n", @html),
-		PTX => join("\n", @ptx),
-	);
+        # cell level
+        $css .= $cellOpts->{cellcss};
+        if ( $cellOpts->{halign} =~ /^([|\s]*\|)/ && $i == 0 ) {
+            my $count = $1 =~ tr/\|//;
+            $css .= css( 'border-left', "solid ${count}px" );
+        }
+        if (   $cellOpts->{halign} =~ /^(\s\|)*!{\\vrule\s+width\s+([^}]*?)}/
+            && $i == 0 )
+        {
+            $css .= css( 'border-left', "solid $2" );
+        }
+        if ( $cellOpts->{halign} =~ /(\|[|\s]*)$/ ) {
+            my $count = $1 =~ tr/\|//;
+            $css .= css( 'border-right', "solid ${count}px" );
+        }
+        if ( $cellOpts->{halign} =~ /!{\\vrule\s+width\s+([^}]*?)}\s*$/ ) {
+            $css .= css( 'border-right', "solid $1" );
+        }
+        $css .= css( 'text-align', 'left' ) if ( $cellOpts->{halign} =~ /^l/ );
+        $css .= css( 'text-align', 'center' )
+          if ( $cellOpts->{halign} =~ /^c/ );
+        $css .= css( 'text-align', 'right' ) if ( $cellOpts->{halign} =~ /^r/ );
+        $css .= css( 'text-align', 'left' )  if ( $cellOpts->{halign} =~ /^p/ );
+        $css .= css( 'width', $1 ) if ( $cellOpts->{halign} =~ /^p{([^}]*?)}/ );
+        $css .= css( 'font-weight', 'bold' )
+          if ( $cellOpts->{tex} =~ /\\bfseries/ );
+        $css .= css( 'font-style', 'italic' )
+          if ( $cellOpts->{tex} =~ /\\itshape/ );
+        $css .= css( 'font-family', 'monospace' )
+          if ( $cellOpts->{tex} =~ /\\ttfamily/ );
 
-	return $return;
+        if ( $cellOpts->{tex} =~ /\\cellcolor(\[HTML\])?{(.*?)[}!]/ ) {
+            $css .= css( 'background-color', ( $1 ? '#' : '' ) . $2 );
+        }
+        if ( $cellOpts->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/ ) {
+            $css .= css( 'color', ( $1 ? '#' : '' ) . $2 );
+        }
+        $css .= $tableOpts->{allcellcss};
+        $css .= $tableOpts->{headercss} if ( $t eq 'th' );
+        $css .= $tableOpts->{datacss}   if ( $t eq 'td' );
+        my $html = $cell;
+        $html = wrap( $cell, @{ $tableOpts->{encase} } )
+          unless $cellOpts->{noencase};
+        if ( $tableOpts->{LaYoUt} ) {
+            $css .= css( 'display', 'table-cell' );
+            my $cellvalign = $tableOpts->{valign};
+            $cellvalign = $valign if ($valign);
+            $css        = css( 'vertical-align', $cellvalign ) . $css;
+            $css        = css( 'padding',        '12pt' ) . $css;
+            if ( $alignment[$i]->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/ )
+            {
+                $css = css( 'background-color', ( $1 ? '#' : '' ) . $2 ) . $css;
+            }
+            $css = css( 'border-right', getRuleCSS( $alignment[$i]->{right} ) )
+              . $css;
+            $html = tag( $html, 'div', { style => $css } );
+        }
+        else {
+            $css  = css( 'padding', '0pt 6pt' ) . $css;
+            $html = tag(
+                $html, $t,
+                {
+                    style   => $css,
+                    scope   => $scope,
+                    colspan => ( $cellOpts->{colspan} > 1 )
+                    ? $cellOpts->{colspan}
+                    : ''
+                }
+            );
+        }
+        push( @html, $html );
 
+        # PTX
+        my $ptx = $cell;
+        $ptx = wrap( $ptx, @{ $tableOpts->{encase} } )
+          unless $cellOpts->{noencase};
+
+# space following p is intentional hack to prevent p from scrubbing by PTX cleanup
+        $ptx = wrap( $ptx, '<p >', '</p >' )
+          if ( $alignment[$i]->{width}
+            or $alignment[$i]->{halign} eq 'X'
+            or $cellOpts->{halign} =~ /^p/ );
+        my $ptxhalign = '';
+        $ptxhalign = 'center' if ( $cellOpts->{halign} =~ /c/ );
+        $ptxhalign = 'right'  if ( $cellOpts->{halign} =~ /r/ );
+        my $ptxright = '';
+        $ptxright = 'minor'  if ( $cellOpts->{halign} =~ /\|\s*$/ );
+        $ptxright = 'medium' if ( $cellOpts->{halign} =~ /\|\s*\|\s*$/ );
+        $ptxright = 'major'  if ( $cellOpts->{halign} =~ /\|\s*\|\s*\|\s*$/ );
+
+        if ( $cellOpts->{halign} =~ /!{\s*\\vrule\s+width\s+([^}]*?)\s*}\s*$/ )
+        {
+            $ptxright = 'minor'  if ($1);
+            $ptxright = 'minor'  if ( $1 == '0.04em' );
+            $ptxright = 'medium' if ( $1 == '0.07em' );
+            $ptxright = 'major'  if ( $1 == '0.11em' );
+        }
+        $ptx = tag(
+            $ptx, 'cell',
+            {
+                halign  => $ptxhalign,
+                colspan => ( $cellOpts->{colspan} > 1 )
+                ? $cellOpts->{colspan}
+                : '',
+                right => $ptxright
+            }
+        );
+        push( @ptx, $ptx );
+    }
+
+    $return = MODES(
+        TeX  => join( " ",  @tex ),
+        HTML => join( "\n", @html ),
+        PTX  => join( "\n", @ptx ),
+    );
+
+    return $return;
 
 }
 
-# Takes the original nested array and returns a simplified version with only the content 
+# Takes the original nested array and returns a simplified version with only the content
 # Also returns the true column count, accounting for colspan
 sub DataArray {
-	my $originalArrayRef = shift;
-	my @originalArray = @$originalArrayRef;
-	my $lastRowIndex = $#originalArray;
-	my @outArray;
-	for my $i (0..$lastRowIndex) {
-		my @outRow;
-		my $originalRowRef = $originalArray[$i];
-		my @originalRow = @$originalRowRef;
-		my $lastColIndex = $#originalRow;
-		for my $j (0..$lastColIndex) {
-			my $originalCell = $originalRow[$j];
-			my $outCell;
-			if (ref($originalCell) eq 'HASH') {
-				$outCell = $originalCell->{'data'};
-			} elsif (ref($originalCell) eq 'ARRAY') {
-				$outCell = $originalCell->[0];
-			} else {
-				$outCell = $originalCell;
-			}
-			$outRow[$j] = $outCell;
-		}
-		my $outRowRef = \@outRow;
-		$outArray[$i] = $outRowRef;
-	}
-	$outArrayRef = \@outArray;
-	return $outArrayRef;
+    my $originalArrayRef = shift;
+    my @originalArray    = @$originalArrayRef;
+    my $lastRowIndex     = $#originalArray;
+    my @outArray;
+    for my $i ( 0 .. $lastRowIndex ) {
+        my @outRow;
+        my $originalRowRef = $originalArray[$i];
+        my @originalRow    = @$originalRowRef;
+        my $lastColIndex   = $#originalRow;
+        for my $j ( 0 .. $lastColIndex ) {
+            my $originalCell = $originalRow[$j];
+            my $outCell;
+            if ( ref($originalCell) eq 'HASH' ) {
+                $outCell = $originalCell->{'data'};
+            }
+            elsif ( ref($originalCell) eq 'ARRAY' ) {
+                $outCell = $originalCell->[0];
+            }
+            else {
+                $outCell = $originalCell;
+            }
+            $outRow[$j] = $outCell;
+        }
+        my $outRowRef = \@outRow;
+        $outArray[$i] = $outRowRef;
+    }
+    $outArrayRef = \@outArray;
+    return $outArrayRef;
 }
 
-# Takes the original nested array and returns a simplified version with only the options as a hash 
+# Takes the original nested array and returns a simplified version with only the options as a hash
 sub OptionsArray {
-	my $originalArrayRef = shift;
-	my @originalArray = @$originalArrayRef;
-	my $lastRowIndex = $#originalArray;
-	my %supportedOptions = (
-		halign => '',
-		header => '',
-		tex => '',
-		noencase => 0,
-		colspan => 1,
-		cellcss => '',
-		texpre => '',
-		texpost => '',
-		rowcolor => '',
-		rowcss => '',
-		headerrow => '',
-		top => 0,
-		bottom => 0,
-		valign => '',
-	);
-	my @outArray;
-	for my $i (0..$lastRowIndex) {
-		my @outRow;
-		my $originalRowRef = $originalArray[$i];
-		my @originalRow = @$originalRowRef;
-		my $lastColIndex = $#originalRow;
-		for my $j (0..$lastColIndex) {
-			my $originalCell = $originalRow[$j];
-			my $outCell;
-			my %outHash = %supportedOptions;
-			if (ref($originalCell) eq 'HASH') {
-				for my $key (keys(%supportedOptions)) {
-					$outHash{$key} = $originalCell->{$key} if defined($originalCell->{$key});
-				}
-				# convenience
-				$outHash{tex} .= '\bfseries' if ($originalCell->{b});
-				$outHash{tex} .= '\itshape' if ($originalCell->{i});
-				$outHash{tex} .= '\ttfamily' if ($originalCell->{m});
-				$outHash{texpre} = $outHash{texpre} . $originalCell->{texencase}->[0] if $originalCell->{texencase};
-				$outHash{texpost} = $originalCell->{texencase}->[1] . $outHash{texpost} if $originalCell->{texencase};
-				# legacy misnomers
-				$outHash{bottom} = $originalCell->{midrule} if (defined($originalCell->{midrule}) && !$outHash{bottom});
-			} elsif (ref($originalCell) eq 'ARRAY') {
-				my @originalOptions = (@$originalCell);
-				my $data = shift(@originalOptions);
-				my %originalOptions = @originalOptions;
-				for my $key (keys(%supportedOptions)) {
-					$outHash{$key} = $originalOptions{$key} if defined($originalOptions{$key});
-				}
-				# convenience
-				$outHash{tex} .= '\bfseries' if ($originalOptions{b});
-				$outHash{tex} .= '\itshape' if ($originalOptions{i});
-				$outHash{tex} .= '\ttfamily' if ($originalOptions{m});
-				$outHash{texpre} = $outHash{texpre} . $originalOptions{texencase}->[0] if $originalOptions{texencase};
-				$outHash{texpost} = $originalOptions{texencase}->[1] . $outHash{texpost} if $originalOptions{texencase};
-				# legacy misnomers
-				$outHash{bottom} = $originalOptions{midrule} if (defined($originalOptions{midrule}) && !$outHash{bottom});
-			}
-			# clean up
-			# remove any left vertical rule specifications from halign
-			if ($j > 0 && $outHash{halign} =~ /((?<!\w)[lcrp](?!\w)\s*(\{[^}]*?\})?(\||!\{[^}]*?\}|\s)*)/) {$outHash{halign} = $1};
+    my $originalArrayRef = shift;
+    my @originalArray    = @$originalArrayRef;
+    my $lastRowIndex     = $#originalArray;
+    my %supportedOptions = (
+        halign    => '',
+        header    => '',
+        tex       => '',
+        noencase  => 0,
+        colspan   => 1,
+        cellcss   => '',
+        texpre    => '',
+        texpost   => '',
+        rowcolor  => '',
+        rowcss    => '',
+        headerrow => '',
+        top       => 0,
+        bottom    => 0,
+        valign    => '',
+    );
+    my @outArray;
+    for my $i ( 0 .. $lastRowIndex ) {
+        my @outRow;
+        my $originalRowRef = $originalArray[$i];
+        my @originalRow    = @$originalRowRef;
+        my $lastColIndex   = $#originalRow;
+        for my $j ( 0 .. $lastColIndex ) {
+            my $originalCell = $originalRow[$j];
+            my $outCell;
+            my %outHash = %supportedOptions;
+            if ( ref($originalCell) eq 'HASH' ) {
+                for my $key ( keys(%supportedOptions) ) {
+                    $outHash{$key} = $originalCell->{$key}
+                      if defined( $originalCell->{$key} );
+                }
 
-			$outCell = \%outHash;
-			$outRow[$j] = $outCell;
-		}
-		my $outRowRef = \@outRow;
-		$outArray[$i] = $outRowRef;
-	}
-	$outArrayRef = \@outArray;
-	return $outArrayRef;
+                # convenience
+                $outHash{tex} .= '\bfseries' if ( $originalCell->{b} );
+                $outHash{tex} .= '\itshape'  if ( $originalCell->{i} );
+                $outHash{tex} .= '\ttfamily' if ( $originalCell->{m} );
+                $outHash{texpre} =
+                  $outHash{texpre} . $originalCell->{texencase}->[0]
+                  if $originalCell->{texencase};
+                $outHash{texpost} =
+                  $originalCell->{texencase}->[1] . $outHash{texpost}
+                  if $originalCell->{texencase};
+
+                # legacy misnomers
+                $outHash{bottom} = $originalCell->{midrule}
+                  if ( defined( $originalCell->{midrule} )
+                    && !$outHash{bottom} );
+            }
+            elsif ( ref($originalCell) eq 'ARRAY' ) {
+                my @originalOptions = (@$originalCell);
+                my $data            = shift(@originalOptions);
+                my %originalOptions = @originalOptions;
+                for my $key ( keys(%supportedOptions) ) {
+                    $outHash{$key} = $originalOptions{$key}
+                      if defined( $originalOptions{$key} );
+                }
+
+                # convenience
+                $outHash{tex} .= '\bfseries' if ( $originalOptions{b} );
+                $outHash{tex} .= '\itshape'  if ( $originalOptions{i} );
+                $outHash{tex} .= '\ttfamily' if ( $originalOptions{m} );
+                $outHash{texpre} =
+                  $outHash{texpre} . $originalOptions{texencase}->[0]
+                  if $originalOptions{texencase};
+                $outHash{texpost} =
+                  $originalOptions{texencase}->[1] . $outHash{texpost}
+                  if $originalOptions{texencase};
+
+                # legacy misnomers
+                $outHash{bottom} = $originalOptions{midrule}
+                  if ( defined( $originalOptions{midrule} )
+                    && !$outHash{bottom} );
+            }
+
+            # clean up
+            # remove any left vertical rule specifications from halign
+            if (   $j > 0
+                && $outHash{halign} =~
+                /((?<!\w)[lcrp](?!\w)\s*(\{[^}]*?\})?(\||!\{[^}]*?\}|\s)*)/ )
+            {
+                $outHash{halign} = $1;
+            }
+
+            $outCell = \%outHash;
+            $outRow[$j] = $outCell;
+        }
+        my $outRowRef = \@outRow;
+        $outArray[$i] = $outRowRef;
+    }
+    $outArrayRef = \@outArray;
+    return $outArrayRef;
 }
 
 sub ColumnCount {
-	my $optsRef = shift;
-	my @options = @$optsRef;
-	my $lastRowIndex = $#options;
-	my $colCount = 0;
-	for my $i (0..$lastRowIndex) {
-		my $rowOptsRef = $options[$i];
-		my @rowOpts = @$rowOptsRef;
-		my $lastColIndex = $#rowOpts;
-		my $thisRowColCount = 0;
-		for my $j (0..$lastColIndex) {
-			$thisRowColCount += $rowOpts[$j]->{colspan};
-		}
-		$colCount = max($colCount, $thisRowColCount);
-	}
-	return $colCount;
+    my $optsRef      = shift;
+    my @options      = @$optsRef;
+    my $lastRowIndex = $#options;
+    my $colCount     = 0;
+    for my $i ( 0 .. $lastRowIndex ) {
+        my $rowOptsRef      = $options[$i];
+        my @rowOpts         = @$rowOptsRef;
+        my $lastColIndex    = $#rowOpts;
+        my $thisRowColCount = 0;
+        for my $j ( 0 .. $lastColIndex ) {
+            $thisRowColCount += $rowOpts[$j]->{colspan};
+        }
+        $colCount = max( $colCount, $thisRowColCount );
+    }
+    return $colCount;
 }
 
 sub TableOptions {
-	my $colCount = shift;
-	my %supportedOptions = (
-		center => 1,
-		caption => '',
-		horizontalrules => 0,
-		texalignment => join('', ('c') x $colCount),
-		Xratio => 0.97,
-		encase => ['',''],
-		rowheaders => 0,
-		tablecss => '',
-		captioncss => '',
-		columnscss => [('') x $colCount],
-		datacss => '',
-		headercss => '',
-		allcellcss => '',
-		valign => 'top',
-		LaYoUt => 0,
-	);
-	%outHash = %supportedOptions;
-	my %userOptions = @_;
-	for my $key (keys(%supportedOptions)) {
-		$outHash{$key} = $userOptions{$key} if defined($userOptions{$key});
-	}
-	# special user shortcut
-	$outHash{texalignment} = $userOptions{align} if (defined($userOptions{align}) && !$userOptions{texalignment});
-	# legacy misnomers
-	$outHash{horizontalrules} = $userOptions{midrules} if (defined($userOptions{midrules}) && !$outHash{horizontalrules});
-	return \%outHash;
+    my $colCount         = shift;
+    my %supportedOptions = (
+        center          => 1,
+        caption         => '',
+        horizontalrules => 0,
+        texalignment    => join( '', ('c') x $colCount ),
+        Xratio          => 0.97,
+        encase          => [ '', '' ],
+        rowheaders      => 0,
+        tablecss        => '',
+        captioncss      => '',
+        columnscss      => [ ('') x $colCount ],
+        datacss         => '',
+        headercss       => '',
+        allcellcss      => '',
+        valign          => 'top',
+        LaYoUt          => 0,
+    );
+    %outHash = %supportedOptions;
+    my %userOptions = @_;
+    for my $key ( keys(%supportedOptions) ) {
+        $outHash{$key} = $userOptions{$key} if defined( $userOptions{$key} );
+    }
+
+    # special user shortcut
+    $outHash{texalignment} = $userOptions{align}
+      if ( defined( $userOptions{align} ) && !$userOptions{texalignment} );
+
+    # legacy misnomers
+    $outHash{horizontalrules} = $userOptions{midrules}
+      if ( defined( $userOptions{midrules} ) && !$outHash{horizontalrules} );
+    return \%outHash;
 }
 
 sub ParseAlignment {
-	my $alignment = shift;
-	# first we parse things like *{20}{...} to expand them
-	my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;
-	while ($alignment =~ /$pattern/) {
-		my @captured = ($alignment =~ /$pattern/);
-		my $replaceWith = $captured[1] x $captured[0];
-		$alignment =~ s/$pattern/$replaceWith/;
-	}
+    my $alignment = shift;
 
-	my @align = ();
-	# 0th entry is only for possible left border
-	# other entries have only right borders,
-	# the actual alignment is r, c, l, X, or p
-	# explicit width vertical rules from !{...}
-	# latex directives from >{...}
-	# we make an array of the tokens of type:
-	# r, c, l, X, |, !{...}, p{...}, >{...}
-	# this is complicated because of potential nested brackets
-	my @tokens = ();
-	my $bracesregex = qr/(\{(?>[^{}]|(?R))*\})/x;
-	my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
-	# . at the end is to ensure we are whittling down $alignment at least a little
-	my $tokenspattern = qr/^([rclX\|]\s*|[!p>]\s*\{((??{$bracecontentsregex}))\}\s*|.)/;
+    # first we parse things like *{20}{...} to expand them
+    my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;
+    while ( $alignment =~ /$pattern/ ) {
+        my @captured    = ( $alignment =~ /$pattern/ );
+        my $replaceWith = $captured[1] x $captured[0];
+        $alignment =~ s/$pattern/$replaceWith/;
+    }
 
-	$align[0] = {left => 0};
-	$leftpattern = '^\s*(\|\s*|!\s*\{\s*\\vrule\s+width\s+([^}]*?)\})';
-	while ($alignment =~ /$leftpattern/) {
-		my $token = $1;
-		if ($token =~ /^\|/) {
-			# this counts how many | we have
-			$align[0]->{left} = 0 unless ($align[$i]->{left} && $align[$i]->{left} =~ /\d+/);
-			$align[0]->{left} += 1;
-		} elsif ($token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/) {
-			$align[0]->{left} = $1;
-		}
-		$alignment =~ s/$leftpattern//;
-	}
-	# now that leftmost vertical rule tokens taken care of, get all the other tokens
-	while ($alignment) {
-		my $token = ($alignment =~ /$tokenspattern/)[0];
-		$alignment =~ s/$tokenspattern//;
-		push(@tokens, $token);
-	}
-	# now run through tokens and grow @align
-	# index for @align
-	my $i = 1;
-	# $j is index for @tokens
-	for my $j (0..$#tokens) {
-		my $token = $tokens[$j];
-		my $next = $tokens[$j+1] // '';
-		if ($token =~ /^([lcrX])/) {
-			$align[$i]->{halign} = $1;
-			$align[$i]->{valign} = 'top' if ($1 eq 'X');
-			$i++ unless ($next =~ /^[|!]/);
-		} elsif ($token =~ /^\|/) {
-			# this counts how many | we have
-			$align[$i]->{right} = 0 unless ($align[$i]->{right} && $align[$i]->{right} =~ /\d+/);
-			$align[$i]->{right} += 1;
-			$i++ unless ($next =~ /^[|!]/);
-		} elsif ($token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/) {
-			# for this style of vertical rule we store the width instead of a small positive integer
-			$align[$i]->{right} = $1;
-			$i++ unless ($next =~ /^[|!]/);
-		} elsif ($token =~ /^p\{((??{$bracecontentsregex}))\}\s*/) {
-			$align[$i]->{halign} = 'l';
-			# record top alignment, but could be overwritten by row valign
-			$align[$i]->{valign} = 'top';
-			$align[$i]->{width} = $1;
-			$i++ unless ($next =~ /^[|!]/);
-		} elsif ($token =~ /^>\s*\{((??{$bracecontentsregex}))\}/) {
-			$align[$i]->{tex} = $1;
-			# could parse these further for color identification, etc
-		}
-	}
-	
-	return \@align;
+    my @align = ();
 
+    # 0th entry is only for possible left border
+    # other entries have only right borders,
+    # the actual alignment is r, c, l, X, or p
+    # explicit width vertical rules from !{...}
+    # latex directives from >{...}
+    # we make an array of the tokens of type:
+    # r, c, l, X, |, !{...}, p{...}, >{...}
+    # this is complicated because of potential nested brackets
+    my @tokens             = ();
+    my $bracesregex        = qr/(\{(?>[^{}]|(?R))*\})/x;
+    my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
+
+  # . at the end is to ensure we are whittling down $alignment at least a little
+    my $tokenspattern =
+      qr/^([rclX\|]\s*|[!p>]\s*\{((??{$bracecontentsregex}))\}\s*|.)/;
+
+    $align[0] = { left => 0 };
+    $leftpattern = '^\s*(\|\s*|!\s*\{\s*\\vrule\s+width\s+([^}]*?)\})';
+    while ( $alignment =~ /$leftpattern/ ) {
+        my $token = $1;
+        if ( $token =~ /^\|/ ) {
+
+            # this counts how many | we have
+            $align[0]->{left} = 0
+              unless ( $align[$i]->{left} && $align[$i]->{left} =~ /\d+/ );
+            $align[0]->{left} += 1;
+        }
+        elsif ( $token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/ ) {
+            $align[0]->{left} = $1;
+        }
+        $alignment =~ s/$leftpattern//;
+    }
+
+# now that leftmost vertical rule tokens taken care of, get all the other tokens
+    while ($alignment) {
+        my $token = ( $alignment =~ /$tokenspattern/ )[0];
+        $alignment =~ s/$tokenspattern//;
+        push( @tokens, $token );
+    }
+
+    # now run through tokens and grow @align
+    # index for @align
+    my $i = 1;
+
+    # $j is index for @tokens
+    for my $j ( 0 .. $#tokens ) {
+        my $token = $tokens[$j];
+        my $next  = $tokens[ $j + 1 ] // '';
+        if ( $token =~ /^([lcrX])/ ) {
+            $align[$i]->{halign} = $1;
+            $align[$i]->{valign} = 'top' if ( $1 eq 'X' );
+            $i++ unless ( $next =~ /^[|!]/ );
+        }
+        elsif ( $token =~ /^\|/ ) {
+
+            # this counts how many | we have
+            $align[$i]->{right} = 0
+              unless ( $align[$i]->{right} && $align[$i]->{right} =~ /\d+/ );
+            $align[$i]->{right} += 1;
+            $i++ unless ( $next =~ /^[|!]/ );
+        }
+        elsif ( $token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/ ) {
+
+# for this style of vertical rule we store the width instead of a small positive integer
+            $align[$i]->{right} = $1;
+            $i++ unless ( $next =~ /^[|!]/ );
+        }
+        elsif ( $token =~ /^p\{((??{$bracecontentsregex}))\}\s*/ ) {
+            $align[$i]->{halign} = 'l';
+
+            # record top alignment, but could be overwritten by row valign
+            $align[$i]->{valign} = 'top';
+            $align[$i]->{width}  = $1;
+            $i++ unless ( $next =~ /^[|!]/ );
+        }
+        elsif ( $token =~ /^>\s*\{((??{$bracecontentsregex}))\}/ ) {
+            $align[$i]->{tex} = $1;
+
+            # could parse these further for color identification, etc
+        }
+    }
+
+    return \@align;
 
 }
 
 sub latexEnvironment {
-	my ($inside, $environment, $options, $separator) = @_;
-	$separator = "\n" unless ($separator);
-	my $return = "\\begin{$environment}";
-	for my $x (@$options) {
-		$return .= "{$x}" if ($x ne '');
-	}
-	$return .= "$separator$inside$separator";
-	$return .= "\\end{$environment}";
-	return $return;
+    my ( $inside, $environment, $options, $separator ) = @_;
+    $separator = "\n" unless ($separator);
+    my $return = "\\begin{$environment}";
+    for my $x (@$options) {
+        $return .= "{$x}" if ( $x ne '' );
+    }
+    $return .= "$separator$inside$separator";
+    $return .= "\\end{$environment}";
+    return $return;
 }
 
 sub latexCommand {
-	my ($command, $arguments) = @_;
-	my $return = "\\$command";
-	for my $x (@$arguments) {
-		$return .= "{$x}" if ($x ne '');
-	}
-	$return .= " ";
-	return $return;
+    my ( $command, $arguments ) = @_;
+    my $return = "\\$command";
+    for my $x (@$arguments) {
+        $return .= "{$x}" if ( $x ne '' );
+    }
+    $return .= " ";
+    return $return;
 }
 
 sub wrap {
-	my ($center, $left, $right, $separator) = @_;
-	$separator = "\n" unless ($separator);
-	return $center unless ($left || $right);
-	return "$left$separator$center" unless $right;
-	return "$center$separator$right" unless $left;
-	return "$left$separator$center$separator$right";
+    my ( $center, $left, $right, $separator ) = @_;
+    $separator = "\n" unless ($separator);
+    return $center                   unless ( $left || $right );
+    return "$left$separator$center"  unless $right;
+    return "$center$separator$right" unless $left;
+    return "$left$separator$center$separator$right";
 }
 
 sub prefix {
-	my ($center, $left, $separator) = @_;
-	$separator = "\n" unless ($separator);
-	return join("$separator",($left, $center)) if ($left ne '');
-	return $center;
+    my ( $center, $left, $separator ) = @_;
+    $separator = "\n" unless ($separator);
+    return join( "$separator", ( $left, $center ) ) if ( $left ne '' );
+    return $center;
 }
 
 sub suffix {
-	my ($center, $right, $separator) = @_;
-	$separator = "\n" unless ($separator);
-	return join("$separator",($center, $right)) if ($right ne '');
-	return $center;
+    my ( $center, $right, $separator ) = @_;
+    $separator = "\n" unless ($separator);
+    return join( "$separator", ( $center, $right ) ) if ( $right ne '' );
+    return $center;
 }
 
 sub css {
-	my ($property, $value) = @_;
-	return ($value) ? "$property:$value;" : '';
+    my ( $property, $value ) = @_;
+    return ($value) ? "$property:$value;" : '';
 }
 
 sub tag {
-	my ($inner, $name, $attributes) = @_;
-	my $return = "<$name";
-	for my $x (lex_sort(keys %$attributes)) {
-		$return .= qq( $x="$attributes->{$x}") if ($attributes->{$x} ne '');
-	}
-	if ($inner) {
-		$return .= ">\n";
-		$return .= $inner;
-		$return .= "\n</$name>";
-	} else {
-		$return .= '>' unless ($main::displayMode eq 'PTX');
-		$return .= '/>' if ($main::displayMode eq 'PTX');
-	}
-	return $return;
+    my ( $inner, $name, $attributes ) = @_;
+    my $return = "<$name";
+    for my $x ( lex_sort( keys %$attributes ) ) {
+        $return .= qq( $x="$attributes->{$x}") if ( $attributes->{$x} ne '' );
+    }
+    if ($inner) {
+        $return .= ">\n";
+        $return .= $inner;
+        $return .= "\n</$name>";
+    }
+    else {
+        $return .= '>' unless ( $main::displayMode eq 'PTX' );
+        $return .= '/>' if ( $main::displayMode eq 'PTX' );
+    }
+    return $return;
 }
 
 sub getRuleCSS {
-	my $input = shift;
-	my $output = '';
-	if ($input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/) {
-		$output = "solid $1px" if $1;
-	} elsif ($input) {
-		$output = "solid $input" if $input;
-	}
-	return $output;
+    my $input  = shift;
+    my $output = '';
+    if ( $input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/ ) {
+        $output = "solid $1px" if $1;
+    }
+    elsif ($input) {
+        $output = "solid $input" if $input;
+    }
+    return $output;
 }
 
 sub getPTXthickness {
-	my $input = shift;
-	my $output = '';
-	if ($input == 1) {
-		$output = "minor";
-	} elsif ($input == 2) {
-		$output = "medium";
-	} elsif ($input >= 3) {
-		$output = "major";
-	} elsif ($input eq '0.04em') {
-		$output = 'minor';
-	} elsif ($input eq '0.07em') {
-		$output = 'medium';
-	} elsif ($input eq '0.11em') {
-		$output = 'major';
-	} elsif ($input) {
-		$output = "minor";
-	}
-	return $output;
+    my $input  = shift;
+    my $output = '';
+    if ( $input == 1 ) {
+        $output = "minor";
+    }
+    elsif ( $input == 2 ) {
+        $output = "medium";
+    }
+    elsif ( $input >= 3 ) {
+        $output = "major";
+    }
+    elsif ( $input eq '0.04em' ) {
+        $output = 'minor';
+    }
+    elsif ( $input eq '0.07em' ) {
+        $output = 'medium';
+    }
+    elsif ( $input eq '0.11em' ) {
+        $output = 'major';
+    }
+    elsif ($input) {
+        $output = "minor";
+    }
+    return $output;
 }
 
 sub getWidthPercent {
-	my $absWidth = shift;
-	my $x = 0;
-	my $unit = 'cm';
-	if ($absWidth =~ /^(\.\d+|\d+\.?\d*)\s*(\w+)/) {
-		$x = $1;
-		$unit = $2;
-	}
-	my %convert_to_cm = (
-		'pt' => 1/864 * 249/250 * 12 * 2.54,
-		'mm' => 1/10,
-		'cm' => 1,
-		'in' => 2.54,
-		'ex' => 0.15132,
-		'em' => 0.35146,
-		'mu' => 0.35146/8,
-		'sp' => 1/864 * 249/250 * 12 * 2.54 / 65536,
-		'bp' => 2.54/72,
-		'dd' => 1/864 * 249/250 * 12 * 2.54 * 1238 /1157,
-		'pc' => 1/864 * 249/250 * 12 * 2.54 * 12,
-		'cc' => 1/864 * 249/250 * 12 * 2.54 * 1238 /1157 * 12,
-		'px' => 2.54/72,
-	);
-	return (int($x * $convert_to_cm{$unit} / (6.25 * 2.54) * 10000)/100) . '%';
+    my $absWidth = shift;
+    my $x        = 0;
+    my $unit     = 'cm';
+    if ( $absWidth =~ /^(\.\d+|\d+\.?\d*)\s*(\w+)/ ) {
+        $x    = $1;
+        $unit = $2;
+    }
+    my %convert_to_cm = (
+        'pt' => 1 / 864 * 249 / 250 * 12 * 2.54,
+        'mm' => 1 / 10,
+        'cm' => 1,
+        'in' => 2.54,
+        'ex' => 0.15132,
+        'em' => 0.35146,
+        'mu' => 0.35146 / 8,
+        'sp' => 1 / 864 * 249 / 250 * 12 * 2.54 / 65536,
+        'bp' => 2.54 / 72,
+        'dd' => 1 / 864 * 249 / 250 * 12 * 2.54 * 1238 / 1157,
+        'pc' => 1 / 864 * 249 / 250 * 12 * 2.54 * 12,
+        'cc' => 1 / 864 * 249 / 250 * 12 * 2.54 * 1238 / 1157 * 12,
+        'px' => 2.54 / 72,
+    );
+    return ( int( $x * $convert_to_cm{$unit} / ( 6.25 * 2.54 ) * 10000 ) / 100 )
+      . '%';
 }
-
 
 1;

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -39,10 +39,10 @@ As much as possible, options can be declared that apply to all output formats.
 Some options are abstracted out to perl. For example center => 0 or 1.
 Some options rely on LaTeX tabular syntax for column alignment, which is parsed
 for use in other output formats. Some settings only apply to HTML styling, and
-seme settings only apply to hardcopy output. Not all fetures are supported in
+seme settings only apply to hardcopy output. Not all features are supported in
 every output format. For example PreTeXt cannot use ccolor information.
 
-All features below apply to DataTable. With LayoutTable, the following fetures
+All features below apply to DataTable. With LayoutTable, the following features
 do not apply or are not implemented:
 	caption
 	rowheaders
@@ -51,7 +51,7 @@ do not apply or are not implemented:
 	headerrow
 Please do use LayoutTable whenever you are really using a table purely for
 layout purposes, for the sake of accessibility.
-	
+
 Options for the WHOLE TABLE
 
 	Applies to on-screen *and* hard copy:
@@ -170,6 +170,8 @@ Options for ROWS
 
 =cut
 
+loadMacros('PGstandard.pl');
+
 sub _niceTables_init { };    # don't reload this file
 
 sub DataTable {
@@ -186,10 +188,10 @@ sub LayoutTable {
 	return DataTable(@_, LaYoUt => 1);
 }
 
-# Make the outer table enovornment
+# Make the outer table environment
 # Handle center, caption, horizontalrules, texalignment, Xratio
 # overall halign OK for tex, ptx but for html must be passed to cells
-# vertical rules from alingment OK
+# vertical rules from alignment OK
 # encase, rowheaders should be passed to cells
 # various css should be self-explanatory
 sub TableEnvironment {
@@ -199,7 +201,7 @@ sub TableEnvironment {
 	# determine if somewhere in the overall alignment, there are X columns
 	my $hasX = 0;
 	for my $align (@alignment) {
-		if ($align->{halign} eq 'X') {
+		if ($align->{halign} && $align->{halign} eq 'X') {
 			$hasX = 1;
 			last;
 		}
@@ -349,7 +351,7 @@ sub Cols {
 		$htmlright .= css('border-right', getRuleCSS($align->{right}));
 
 		$htmlcolcss = $columnscss->[$i];
-		if ($align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
+		if (defined($align->{text}) && $align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
 			$htmlcolcss .= css('background-color', ($1 ? '#' : '') . $2);
 		}
 
@@ -483,7 +485,7 @@ sub Rows {
 		$ptxleft = 'medium' if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|/);
 		$ptxleft = 'major'  if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|\s*\|/);
 
-		if ($rowOpts->[0]->{halign} =~ /^(?:\s|\|)*!{\s*\\vrule\s+width\s+([^}]*?)\s*}/) {
+		if ($rowOpts->[0]->{halign} =~ /^(?:\s|\|)*!\{\s*\\vrule\s+width\s+([^}]*?)\s*\}/) {
 			$ptxleft = 'minor'  if ($1);
 			$ptxleft = 'minor'  if ($1 == '0.04em');
 			$ptxleft = 'medium' if ($1 == '0.07em');
@@ -639,18 +641,18 @@ sub Row {
 
 		# col level
 		$css .= css('text-align', 'center')
-			if ($alignment[$i]->{halign} eq 'c');
+			if (defined($alignment[$i]->{halign}) && $alignment[$i]->{halign} eq 'c');
 		$css .= css('text-align', 'right')
-			if ($alignment[$i]->{halign} eq 'r');
+			if (defined($alignment[$i]->{halign}) && $alignment[$i]->{halign} eq 'r');
 		$css .= css('width', $alignment[$i]->{width})
 			if ($alignment[$i]->{width});
 		$css .= css('font-weight', 'bold')
-			if ($alignment[$i]->{tex} =~ /\\bfseries/);
+			if (defined($alignment[$i]->{tex}) && $alignment[$i]->{tex} =~ /\\bfseries/);
 		$css .= css('font-style', 'italic')
-			if ($alignment[$i]->{tex} =~ /\\itshape/);
+			if (defined($alignment[$i]->{tex}) && $alignment[$i]->{tex} =~ /\\itshape/);
 		$css .= css('font-family', 'monospace')
-			if ($alignment[$i]->{tex} =~ /\\ttfamily/);
-		if ($alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
+			if (defined($alignment[$i]->{tex}) && $alignment[$i]->{tex} =~ /\\ttfamily/);
+		if (defined($alignment[$i]->{tex}) && $alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
 			$css .= css('color', ($1 ? '#' : '') . $2);
 		}
 
@@ -660,7 +662,7 @@ sub Row {
 			my $count = $1 =~ tr/\|//;
 			$css .= css('border-left', "solid ${count}px");
 		}
-		if ($cellOpts->{halign} =~ /^(\s\|)*!{\\vrule\s+width\s+([^}]*?)}/
+		if ($cellOpts->{halign} =~ /^(\s\|)*!\{\\vrule\s+width\s+([^}]*?)\}/
 			&& $i == 0)
 		{
 			$css .= css('border-left', "solid $2");
@@ -669,7 +671,7 @@ sub Row {
 			my $count = $1 =~ tr/\|//;
 			$css .= css('border-right', "solid ${count}px");
 		}
-		if ($cellOpts->{halign} =~ /!{\\vrule\s+width\s+([^}]*?)}\s*$/) {
+		if ($cellOpts->{halign} =~ /!\{\\vrule\s+width\s+([^}]*?)\}\s*$/) {
 			$css .= css('border-right', "solid $1");
 		}
 		$css .= css('text-align', 'left') if ($cellOpts->{halign} =~ /^l/);
@@ -1098,7 +1100,7 @@ sub tag {
 	my ($inner, $name, $attributes) = @_;
 	my $return = "<$name";
 	for my $x (lex_sort(keys %$attributes)) {
-		$return .= qq( $x="$attributes->{$x}") if ($attributes->{$x} ne '');
+		$return .= qq( $x="$attributes->{$x}") if (defined($attributes->{$x}) && $attributes->{$x} ne '');
 	}
 	if ($inner) {
 		$return .= ">\n";
@@ -1114,7 +1116,7 @@ sub tag {
 sub getRuleCSS {
 	my $input  = shift;
 	my $output = '';
-	if ($input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/) {
+	if (defined($input) && $input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/) {
 		$output = "solid $1px" if $1;
 	} elsif ($input) {
 		$output = "solid $input" if $input;
@@ -1123,7 +1125,8 @@ sub getRuleCSS {
 }
 
 sub getPTXthickness {
-	my $input  = shift;
+	# assume that the default input is 2 if not defined.
+	my $input  = shift // 2;
 	my $output = '';
 	if ($input == 1) {
 		$output = "minor";

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -221,6 +221,7 @@ sub TableEnvironment {
 	my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
 	$tex = latexEnvironment($tex, $tabulartype, [ $tabularwidth, $tableOpts->{texalignment} ], ' ');
 	$tex = prefix($tex, '\centering') if $tableOpts->{center};
+	$tex = prefix($tex, '\renewcommand{\arraystretch}{2}') if $tableOpts->{LaYoUt};
 	$tex =
 		suffix($tex,
 			"\\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\\captionof*{table}{$tableOpts->{caption}}")

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -1,837 +1,987 @@
-
 =head1 niceTables.pl
 
+
 Subroutines for creating tables that
-    * conform to accessibility standards
-    * allow a lot of CSS flexibility for on-screen styling
-    * allow some LaTeX flexibility for hard copy styling
+	* conform to accessibility standards
+	* may use CSS for HTML styling
+	* may use some LaTeX hardcopy styling
 
-Hard copy data tables will always have a top rule, bottom rule, and midrule after any header row
+DataTable()	Creates a table with data.
+		Should not be used for layout, such as displaying an array of graphs.
 
-DataTable()             Creates a table with data.
-                                 Should not be used for layout, such as displaying an array of graphs.
-                                 Should usually make use of a caption and column and/or row headers.
+LayoutTable()	Creates a "table" using div boxes for layout
 
-LayoutTable()           Creates a "table" using div boxes for layout
-
-NOTE: In order to reduce separate setting of on-screen and hard copy settings as much as possible, Perl 5.10+
-tools are used. These macros may behave unexpectedly or not work at all with older versions of Perl.
-These macros use LaTeX packages in the hard copy that wer not formerly part of a WeBWorK hard copy preamble.
-Your LaTeX distribution needs to have the packages: booktabs, tabularx, colortbl, caption, xcolor
-And if you have a WeBWorK version earlier than 2.10, you need to add calls to these packages to hardcopyPreamble.tex
-  in webwork2/conf/snippets/
+NOTE: This macro file uses Perl 5.10+ tools. These macros may behave
+unexpectedly or not work at all with older versions of Perl.
 
 =head2 Description
 
-Command for tables displaying data. In a data table the xy-position of a cell is somehow
-important along with the information inside the cell.
+Command for a typical table.
 
-	Usage:  DataTable([[a,b,c,...],[d,e,f,...],[g,h,i,...],...], options);
+	DataTable([
+		[a,b,c,...],
+		[d,e,f,...],
+		...
+		],
+		options
+	);
 
-	[[a,b,c,...],[d,e,f,...],[g,h,i,...],...] is the table content, row by row
+	LayoutTable([
+		[a,b,c,...],
+		[d,e,f,...],
+		...
+		],
+		options
+	);
 
-As much as possible, options can be declared to simultaneously apply to both on-screen and hard copy.
-Generally, you give settings for the hard copy tex version first. Many common such settings are automatically
-translated into CSS styling for the on-screen. You can then override or augment the CSS for the on-screen version.
+As much as possible, options can be declared that apply to all output formats.
+Some options are abstracted out to perl. For example center => 0 or 1.
+Some options rely on LaTeX tabular syntax for column alignment, which is parsed
+for use in other output formats. Some settings only apply to HTML styling, and
+seme settings only apply to hardcopy output. Not all fetures are supported in
+every output format. For example PreTeXt cannot use ccolor information.
 
-With PTX output, not all features below are supported. Perhaps they can be added upon request.
-Contact Alex Jordan with questions.
-This version supports the center, caption, midrules, encase, and noencase options in PTX. It also honors the
-horizontal alignment portions of the align option (but not vertical rules or anything found in @{}).
-
+All features below apply to DataTable. With LayoutTable, the following fetures
+do not apply or are not implemented:
+	caption
+	rowheaders
+	header
+	colspan
+	headerrow
+Please do use LayoutTable whenever you are really using a table purely for
+layout purposes, for the sake of accessibility.
+	
 Options for the WHOLE TABLE
 
-    Applies to on-screen *and* hard copy:
-      center => 0 or 1              # center table
-      caption => string             # a caption for the table
-      midrules => 0 or 1            # if you want rules above and below every row
-                                    #   (hard copies will always have toprule and bottomrule)
-      align => string               # an alignment string like the kinds used in LaTeX tabular environments;
-                                    # some of what you specify here will apply to both on-screen and hard copy
-        (texalignment => string     #  -what won't is specified further below
-         is really what it is,      # for example 'rccp{1in}' would be for a four-column table with a
-         but align is a shortcut)   #   right-aligned column, two centered columns,
-                                    #   and a paragraph column of fixed width 1in; defaults to all c's;
-                                    # r is for right-alignment; on-screen will have no wrap
-                                    # c for center; on-screen will have no wrap
-                                    # l for left; on-screen will have no wrap
-                                    # p{width} is for a fixed-width paragraph column
-                                    #   -width should be a valid tex width; if it is also a valid css width,
-                                    #   -it will be used on-screen too; otherwise, on-screen will have unspecified width
-      Xratio => 0.97                # X ...if X is used in column alignment then the hard copy will have a width that
-                                    #   is Xratio times the \linewidth, and X columns will be paragraph columns that
-                                    #   grow to be whatever width fills the overall table width. For on-screen, X is
-                                    #   a normal breaking-paragraph column that will expand to screen width before
-                                    #   a break happens
-                                    # | as with array environments in LaTeX, you may use | for vertical rules.
-                                    # Preceding one of the above alignment types, you may use >{...} where the ... is
-                                    #   more LaTeX commands to be applied everywhere in the column. For the simple text
-                                    #   syling commands: \bfseries for bold, \itshape for italic, or \ttfamily for
-                                    #   teletype (monospaced font), the on-screen version will be applied too.
-                                    #  *You may include \color{...} here too, where ... is a coloring mixture from the
-                                    #   xcolor package. 'blue' is an example of the simplest coloring mixture. For a much
-                                    #   more complicated example: rgb:blue!30!green,1;-red!10!green,2 would give 1 part
-                                    #   a 30%blue-70%green mixture, mixed with 2 parts the complement of a
-                                    #   10%red-90%green mixture.
-                                    #     -only mixtures like \color{blue...} will be respected on-screen, and in that
-                                    #     -case the first color will named be used. Use columnscss (discussed below) if
-                                    #     -want to be more picky with the on-screen version.
-                                    #  *You may include \columncolor{...} to color the background of cells, where ...
-                                    #   follows the same rules as for \color{...}
-                                    #  NOTE: Any color commands (\color, \columncolor, \rowcolor, \cellcolor) can take the
-                                    #    option [HTML] and then an HTML hexadecimal color can be declared. For example,
-                                    #    \color[HTML]{FF0000} for red. It works for on-screen and hard copy. Color
-                                    #    specified this way should be the same on-screen and in the hard copy, whereas
-                                    #    color specified the other way often differs.
-                                    #   Any more complicated tex commands will be ignored for on-screen (or cause errors
-                                    #     or not behave as expected).
-      encase => array ref           # You may want to encase all table entries in, say, \( and \) to save from typing
-                                    #   them many times. To do that, use encase => ['\(','\)']. For individual cells
-                                    #   you may set noencase=>1 to omit this (see section on modifying cells).
-      rowheaders => 1               # Make the first element of every row a row header.
+	Applies to on-screen *and* hard copy:
+		center => 0 or 1           # center the table (default 1)
+		caption => string          # caption for the table
+		horizontalrules => 0 or 1  # for rules above and below every row
+		texalignment => string     # an alignment string like the kinds used in
+		  (align for short)        # LaTeX tabular environments. For example 'r|ccp{1in}'
+		                           # r, c, l for right-aligned, left-aligned, centered
+		                           # p{width} for a left-aligned paragraph of fixed (absolute) width
+		                           # X for a left-aligned paragraph that expands to fill width
+		                           #   (see Xratio below)
+		                           # | for a simpl vertical rule
+		                           # !{\vrule width ...} where ... is an absolute width; makes a
+		                           #   vertical rule of the indicated width. Syntax should not deviate
+		                           #   or else it may not work in non-LaTeX output.
+		                           # >{LaTeX commands} will execute those LaTeX commands at each cell
+		                           #   in the column. For example, 'c>{\color{blue}}c' will make the
+		                           #   second column have blue text.
+		                           #   The following such LaTeX commands will be respected by HTML:
+		                           #     \color{colorname}
+		                           #     \color[HTML]{xxxxxx} where xxxxxx is a hex color code
+		                           #     \columncolor{colorname} to set the background color
+		                           #     \columncolor[HTML]{xxxxxx}
+		                           #     \bfseries for bold
+		                           #     \itshape for italics
+		                           #     \ttfamily for monospace font
+		                           #   All other such commands will only apply to hardcopy output.
+		                           #
+		                           #
+		Xratio => 0.97 (default)   # some number with 0 < Xratio <= 1. If X is used in column alignment
+		                           # then the table will only be Xratio wide relative to the overall
+		                           # horizontal space. Then the X columns expland to fill available space.
+		encase => [ , ]            # Encases all table entries in the two entries. Most commonly used to
+                                           # wrap math delimiters if you want all content in math mode. In that
+		                           # case, use [$BM,$EM]. Also, see noencase below for individual cells.
+		rowheaders => 0 or 1       # Make the first element of every row a row header. This impacts
+                                           # styling, but also affects HTML structure for accessibility
+		valign => 'top'            # Can be 'top', 'middle', or 'bottom'. Applies to all rows. See
+		                           # below to override for an indiviidual row.
 
-    Applies to on-screen:
-      tablecss => string            # css styling commands for the table element (see below for css syntax)
-      captioncss => string          # css styling commands for the caption element (see below for css syntax)
-      columnscss => array ref       # an array reference to css styling commands (strings) for columns
-                                    #   use empty strings for columns for which you have no style specifications
-                                    #   Ex: columnscss => ['','background-color:yellow;','','background-color:yellow;']
-                                    #   -specifications made here overrule specifications from texalignment
-      datacss => string             # css styling commands for all the td elements (see below for css syntax)
-      headercss => string           # css styling commands for the th elements (see below for css syntax)
-      allcellcss => string          # css styling commands for all the cells (see below for css syntax)
+	Applies to on-screen:              # These are strings with css properties. Each property:value pair
+	                                   # should end with a semicolon.
+		tablecss => string         # css styling commands for the table element
+		captioncss => string       # css styling commands for the caption element
+		columnscss => array ref    # an array reference to css styling commands for columns
+		                           # Note the only four css properties that apply to col elements are
+		                           # 'border' (family), 'background' (family), 'width', 'column-span'
+		datacss => string          # css styling commands for all the td elements
+		headercss => string        # css styling commands for the th elements
+		allcellcss => string       # css styling commands for all the cells
 
 
-MODIFYING CELLS
+Options for CELLS
 
-  Each cell entry (like "a" in [[a,b,c,...],...])) can be replaced with an array reference (encased in square brackets) for
-  more detailed customization of that cell. For example, [[[a,header=>'CH'],b,c],[d,e,f]] gives a table where the a is
-  a column header cell. The data content of the cell must be the first element listed, and what follows must be key=>value pairs.
-  These options may be applied.
+	Each cell entry can be an array reference where the first entry is the actual
+	cell content, and then key-value pairs follow. For example, one row might be
+	[[a, colspan => 2], b, c]
+	in a four-column table where this row's first cell occupies two columns. You
+	may use an array reference instead, like
+	[{data => a, colspan => 2}, b, c]
 
-    Applies to both on-screen and hard copy:
-      halign => string              # same format as align at the table level (discussed above) but for one cell only
-      header => type,               # Could be 'TH' (table header), 'CH', 'col', or 'column' (col header), 'RH', or 'row'
-                                    #   (row header). If so, default CSS styling is used, and hard copy cell is bold.
-                                    # Can also be 'TD' to overrule a row of all headers (see modifying rows)
-                                    # If your table only has column headers (no row headers) it is probably best to make
-                                    #   an entire row of headers (see modifying a row) and to not use header=> directly.
-                                    #   But if your table has both column and row headers then use header=> for all the
-                                    #   headers (both row- and column-) and don't use the row modification (because in
-                                    #   that situation you probably don't want a THEAD tag).
-      tex => tex code               # For tex commands whose scope will be entire cell, e.g. \bfseries or \itshape;
-                                    #   \bfseries (for bold), \itshape (for italic), and \ttfamily (for monospace) will
-                                    #   lead to CSS equivalents for the on-screen version
-                                    # For cell coloring: like \cellcolor{blue} for the background or \color{blue} for the
-                                    #   text, use color mixtures as described in texalignment=>, and simple colors will
-                                    #   apply to the on-screen version too.
-                                    # -all other tex code will be ignored for the on-screen version, so use cellcss=>
-                                    #  below
-      b=>1, i=>1, m=>1              # These are shortcuts for adding \bfseries, \itshape, and \ttfamily to tex, which will
-                                    #   in turn affect he on-screen too.
-      noencase => 1                 # If you have global encase strings (see section on modifying the whole table) then
-                                    #   you can opt to not apply them on a cell by cell basis
-      colspan => pos integer        # for cells that span more than one column; when using this, you must set halign for
-                                    #   the cell too, or else the tex output will just use {c} alignment; this feature may
-                                    #   not behave as expected for certain structures, like a two-row table, with 3 columns,
-                                    #   but the first row has colspans 2 and 1 with the second row having colspans 1 and 2
-                                    # **colspan is supported for DataTable only, not LayoutTable. LayoutTable uses css
-                                    #   like display:table-cell; to achieve its output, and there is no counterpart to
-                                    #   colspan using this approach (at least not currently)
+	Applies to both on-screen and hard copy:
+		halign => string           # Similar to the components for texalignment above
+		                           # However, only l, c, r, p{width}, |, and !{\vrule width ...} should
+		                           # be used.
+		                           # With the vertical rule specifiers, any left vertical rule will only
+		                           # be observed if it is in the first column.
+		header => type,            # Influences the "scope" of the HTML th elemeent. Case-insensitives:
+		                           #   'th' for generic table header
+		                           #   'ch', 'col', or 'column' for column header
+		                           #   'rh' or 'row' for row header
+		                           #   'td' to override a headerrow or rowheaders directive
+		tex => tex code            # For tex commands whose scope will be entire cell
+		                           #   The following such LaTeX commands will be respected by HTML:
+		                           #     \color{colorname}
+		                           #     \color[HTML]{xxxxxx} where xxxxxx is a hex color code
+		                           #     \cellcolor{colorname} to set the background color
+		                           #     \cellcolor[HTML]{xxxxxx}
+		                           #     \bfseries for bold
+		                           #     \itshape for italics
+		                           #     \ttfamily for monospace font
+		                           #   All other such commands will only apply to hardcopy output.
+ 		b=>1, i=>1, m=>1           # These are shortcuts for having \bfseries, \itshape, and \ttfamily in tex
+		noencase => 0 or 1         # If you are using encase (see above) use this to opt out for any one cell
+		colspan => n               # Should be a positive integer; for cells that span more than one column
+		                           #   when using this, you often want to set halign as well. This feature may
+		                           #   not behave as expected for complicated colspan commbinations
 
-    Applies to on-screen:
-      cellcss => string,            # String with cell-specific CSS styling; see below for CSS syntax
+	Applies to on-screen:
+		cellcss => string          # css styling commands for this cell
 
-    Applies to hard copy:
-      texpre => tex code,           # For more fussy cell-by-cell alteration of the tex version of the table
-                                    # TeX code here will precede the cell entry...
-      texpost => tex code           # and code here will follow the cell entry
-                                    # The ordering will be: texpre tex data texpost
-      texencase => array ref        # This is just a shortcut for entering [texpre,texpost] at once.
-
-  The "a" in a cell can also be replaced directly with a hash reference {data=>a,options} if somehow that is of use. If you
-  modify the cell using an array reference [a, options] instead, it is automatically converted to a hash reference anyway.
+	Applies to hard copy:
+		texpre => tex code         # For more fussy cell-by-cell alteration of the tex version of the table
+                texpost => tex code        #   code to place before and after the cell content
+		texencase => array ref     # This is just a shortcut for entering [texpre,texpost] at once.
 
 
-MODIFYING ROWS
+Options for ROWS
 
- You can give a row background color using arguments from colortbl's \rowcolor command:
-    [[[a, rowcolor => '{blue!50}'],b,c,...],[d,e,f,...],[g,h,i,...],...]
-    [[[a, rowcolor => '[HTML]{FF0000}'],b,c,...],[d,e,f,...],[g,h,i,...],...]
- For the on-screen version, if the first style of argument is used, only the first color mentioned will be used.
+	Some parameters in a cell's options array acctually affect the entire row.
+	When there is a clash, the last declaration in the row will be used.
 
- A rowcss key can be used anywhere in the row. Only the last instance in that row will be applied.
-    [[[a, rowcss => extra css for the row],b,c,...],[d,e,f,...],[g,h,i,...],...]
+	Applies to both on-screen and hard copy:
+		rowcolor => string         # This must either be in the form 'colorname' or '[HTML]{color}'.
+		                           #   It affects the row's background color.
+		rowcss => string           # css styling commands for the row
+		headerrow => 0 or 1        # Makes an entire row have header cells (with column scope)
+		top => +int or string      # When used on the first row, creates a top rule
+		                           #   Thickness is either n pixels or a width like '0.04em'.
+		bottom => +int or string   # Creates a bottom rule
+		                           #   Thickness is either n pixels or a width like '0.04em'.
+		valign => string           # Override table's overall vertical alignment for this row
+		                           #   Can be 'top', 'middle', or 'bottom'
 
- You can make an entire row be made of CH (column header) elements without specifying it for each header:
-    [[[a, headerrow=>1],b,c,...],[d,e,f,...],[g,h,i,...],...]
- This also encases the row in a <THEAD> tag. This should only be applied to the first row. In the hard copy,
-    a row like this will have bold entries and be followed by a midrule.
-
- And you can follow a row with a horizontal rule:
-    [[[a, midrule => 1],b,c,...],[d,e,f,...],[g,h,i,...],...]
-    (but this is already done once for headerrows in the hard copy, since they don't rely on surrounding CSS to stand out)
-
-CSS SYNTAX PRIMER
-
-      css styling commands offer a huge variety for styling the table on screen
-      Basic elements are of the form "A:B;" like "border:1pt;" and "width:80%;"
-      ****DON'T FORGET THE SEMICOLONS. SINCE THESE COMMANDS ACCUMULATE, SEMICOLONS ARE IMPORTANT.
-      Also, they can be of the form "A:B C;" like "border:1pt dashed;"
-      Multiple commands can be used with the form "A1:B;A2:C;" like "border:1pt; margin:5pt;"
-      Some properties with example values and which elements they can affect:
-          border:2px solid blue;                      table, caption, th, td
-          border-collapse:collapse;  (or separate)    table
-          border-radius: 5px;                         table, caption, tr, th, td
-          width:50%;                                  table, caption, th, td
-          height:20ex;                                table, caption, tr, th, td
-          text-align:center;                          table, caption, tr, th, td
-          vertical-align:top;                         table, caption, tr, th, td
-          padding:12pt;                               table, caption, th, td
-          margin:20px;                                table, caption
-          border-spacing:12pt;                        table
-          caption-side:bottom;                        table, caption
-          color:blue;                                 table, caption, tr, th, td
-          background-color:yellow;                    table, caption, tr, th, td
-          font-weight:bold;                           table, caption, tr, th, td
-          font-style:italic;                          table, caption, tr, th, td
-          font-family:monospace;                      table, caption, tr, th, td
-      The properties border, padding, and margin
-          can be specified in more detail using -left, -bottom, -right, -top as in "border-bottom:5px"
-
-	Example: DataTable([[[1, header => 'CH', cellcss => 'font-family:fantasy;'],2,3],
-                    [4,5,[6, rowcss => 'padding-top:10pt; padding-bottom:10pt; ']]],
-                     tablecss => "border:solid 1px; border-spacing:5px; border-radius: 5px; border-collapse:separate;");
 
 =cut
 
-# ^uses loadMacros
-loadMacros("PGauxiliaryFunctions.pl");
-
-sub _niceTables_init { };    # don't reload this file
+sub _niceTables_init {}; # don't reload this file
 
 sub DataTable {
-	my $dataref = shift;
-
-	# this array will store the number of cells in each row
-	my @numcols = ();
-
-	# if any cells were simply entered as their data value or an array ref, convert to a hash
-	for my $i (0 .. $#{$dataref}) {
-		$numcols[$i] = $#{ $dataref->[$i] };
-		for my $j (0 .. $numcols[$i]) {    # if cell was simply entered as data value, make the hash
-			$dataref->[$i][$j] = { data => $dataref->[$i][$j] }
-				unless (ref($dataref->[$i][$j]) eq "HASH" or ref($dataref->[$i][$j]) eq "ARRAY");
-			# and if it was entered as an array reference, make the hash
-			if (ref($dataref->[$i][$j]) eq "ARRAY") {
-				my $temp = $dataref->[$i][$j];
-				$dataref->[$i][$j] = { "data", @$temp };
-			}
-			#before [a, options] was an option, {d=>a,options} was a shortcut for {data=>a,options}
-			${ $dataref->[$i][$j] }{data} = ${ $dataref->[$i][$j] }{d} if (defined ${ $dataref->[$i][$j] }{d});
-			# set default values for cell
-			${ $dataref->[$i][$j] }{header}    = ''         unless (defined ${ $dataref->[$i][$j] }{header});
-			${ $dataref->[$i][$j] }{tex}       = ''         unless (defined ${ $dataref->[$i][$j] }{tex});
-			${ $dataref->[$i][$j] }{b}         = 0          unless (defined ${ $dataref->[$i][$j] }{b});
-			${ $dataref->[$i][$j] }{i}         = 0          unless (defined ${ $dataref->[$i][$j] }{i});
-			${ $dataref->[$i][$j] }{m}         = 0          unless (defined ${ $dataref->[$i][$j] }{m});
-			${ $dataref->[$i][$j] }{noencase}  = 0          unless (defined ${ $dataref->[$i][$j] }{noencase});
-			${ $dataref->[$i][$j] }{halign}    = ''         unless (defined ${ $dataref->[$i][$j] }{halign});
-			${ $dataref->[$i][$j] }{colspan}   = ''         unless (defined ${ $dataref->[$i][$j] }{colspan});
-			${ $dataref->[$i][$j] }{cellcss}   = ''         unless (defined ${ $dataref->[$i][$j] }{cellcss});
-			${ $dataref->[$i][$j] }{rowcss}    = ''         unless (defined ${ $dataref->[$i][$j] }{rowcss});
-			${ $dataref->[$i][$j] }{rowcolor}  = ''         unless (defined ${ $dataref->[$i][$j] }{rowcolor});
-			${ $dataref->[$i][$j] }{midrule}   = 0          unless (defined ${ $dataref->[$i][$j] }{midrule});
-			${ $dataref->[$i][$j] }{headerrow} = 0          unless (defined ${ $dataref->[$i][$j] }{headerrow});
-			${ $dataref->[$i][$j] }{texencase} = [ '', '' ] unless (defined ${ $dataref->[$i][$j] }{texencase});
-			${ $dataref->[$i][$j] }{texpre}    = ${ $dataref->[$i][$j] }{texencase}->[0]
-				unless (defined ${ $dataref->[$i][$j] }{texpre});
-			${ $dataref->[$i][$j] }{texpost} = ${ $dataref->[$i][$j] }{texencase}->[1]
-				unless (defined ${ $dataref->[$i][$j] }{texpost});
-		}
-	}
-
-	# total number of columns
-	my $numcol = max(@numcols) + 1;
-
-	# define options
-	my %options = (
-		center       => 1,
-		caption      => '',
-		tablecss     => '',
-		captioncss   => '',
-		datacss      => '',
-		headercss    => '',
-		allcellcss   => '',
-		texalignment => join('', ('c') x $numcol),
-		rowheaders   => 0,
-		midrules     => 0,
-		columnscss   => [ ('') x $numcol ],
-		Xratio       => 0.97,
-		encase       => [ '', '' ],
-		LaYoUt       => 0,
-		@_
-	);
-	if ($options{LaYoUt} != 1) { $options{allcellcss} = 'padding-left:6pt; padding-right:6pt; ' . $options{allcellcss} }
-	else                       { $options{allcellcss} = 'padding:12pt; ' . $options{allcellcss} }
-	$options{captioncss} = 'padding:6pt; ' . $options{captioncss};
-	$options{tablecss}   = 'border-collapse:collapse; ' . $options{tablecss};
-
-	my $caption = $options{caption};
-	my (
-		$tablecss,     $captioncss, $datacss,    $headercss, $allcellcss,
-		$texalignment, $midrules,   $columnscss, $Xratio,    $encase
-		)
-		= (
-			$options{tablecss},   $options{captioncss},   $options{datacss},  $options{headercss},
-			$options{allcellcss}, $options{texalignment}, $options{midrules}, $options{columnscss},
-			$options{Xratio},     $options{encase}
-		);
-	my $center = $options{center};
-	if ($center != 0) { $tablecss .= 'text-align:center; margin:0 auto; ' }
-
-	# shortcuts introduced late
-	if (defined $options{align}) { $texalignment = $options{align} }
-	if ($options{rowheaders} == 1) {
-		for my $i (0 .. $#{$dataref}) {
-			${ $dataref->[$i][0] }{header} = 'RH' if (uc(${ $dataref->[$i][0] }{header}) eq '');
-		}
-	}
-
-	# apply contents of encase; cell shortcuts
-	for my $i (0 .. $#{$dataref}) {
-		for my $j (0 .. $numcols[$i]) {
-			${ $dataref->[$i][$j] }{data} = $encase->[0] . ${ $dataref->[$i][$j] }{data} . $encase->[1]
-				unless (${ $dataref->[$i][$j] }{noencase} == 1);
-			if (${ $dataref->[$i][$j] }{b} == 1) { ${ $dataref->[$i][$j] }{tex} .= '\bfseries '; }
-			if (${ $dataref->[$i][$j] }{i} == 1) { ${ $dataref->[$i][$j] }{tex} .= '\itshape '; }
-			if (${ $dataref->[$i][$j] }{m} == 1) { ${ $dataref->[$i][$j] }{tex} .= '\ttfamily '; }
-		}
-	}
-
-	# for each row, store rowcss, rowcolor, midrule, headerrow
-	my @rowcss    = ();
-	my @rowcolor  = ();
-	my @midrule   = ();
-	my @headerrow = ();
-	for my $i (0 .. $#{$dataref}) {
-		$rowcss[$i]    = '';
-		$rowcolor[$i]  = '';
-		$midrule[$i]   = 0;
-		$headerrow[$i] = 0;
-		for my $j (0 .. $numcols[$i]) {
-			$rowcss[$i]    = ${ $dataref->[$i][$j] }{rowcss}    if ($rowcss[$i] eq '');
-			$rowcolor[$i]  = ${ $dataref->[$i][$j] }{rowcolor}  if ($rowcolor[$i] eq '');
-			$midrule[$i]   = ${ $dataref->[$i][$j] }{midrule}   if ($midrule[$i] == 0);
-			$headerrow[$i] = ${ $dataref->[$i][$j] }{headerrow} if ($headerrow[$i] == 0);
-		}
-		if ($rowcolor[$i] =~ /\{\s*(\w*)[}!]/) {
-			$rowcss[$i] = 'background-color:' . $1 . '; ' . $rowcss[$i];
-		}
-		if ($rowcolor[$i] =~ /\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-			$rowcss[$i] = 'background-color:#' . $1 . '; ' . $rowcss[$i];
-		}
-	}
-
-	# parse tex alignment for duplicate use in html
-	my $bracesregex = qr/(\{(?>[^{}]|(?R))*\})/x;
-	# grabs outer level braces and their contents, including inner brace pairs
-	my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
-	# grabs contents of an outer level brace pair, including inner brace pairs
-	my @htmlalignment = split(/(>\s*(??{$bracesregex})\s*|\|\s*|p\s*(??{$bracesregex})\s*|[rclX]\s*)/, $texalignment);
-	my @temp          = ();
-	foreach (@htmlalignment) {
-		if ((defined $_) and ($_ ne '')) {
-			push(@temp, $_);
-		}
-	}
-	@htmlalignment = @temp;
-	# @htmlalignment is now an array, where the entries are the parsed pieces of $texalignment; entries parsed by
-	# >{commands}, pipes (for vertical rules), p{width}, r, c, l, or X
-
-	my @columnalignments = grep { $htmlalignment[$_] =~ /^p\s*(??{$bracesregex})\s*|^[rclX]\s*/ } 0 .. $#htmlalignment;
-	# @columnalignments is an array, where the entries are the indices form @htmlalignment that actually deal with
-	# alignment: p{width}, r, c, l, or X
-	my @alignmentcolumns;
-	for my $i (0 .. $#columnalignments) { $alignmentcolumns[ $columnalignments[$i] ] = $i }
-	# @alignmentcolumns is an array whose ith element is undefined unless the ith element of @htmlalignment was one
-	# of p{width}, r, c, l, or X. Otherwise it is the index of the entry in @columnalignments that corresponds to
-	# that alignment
-
-	# append css to author's columnscss->[$i] that corresponds to the alignemnts in @alignmentcolumns
-	for my $i (0 .. $#columnalignments) {
-		$columnscss->[$i] = TeX_Alignment_to_CSS($htmlalignment[ $columnalignments[$i] ]) . $columnscss->[$i];
-	}
-	# append css to author's columnscss->[$i] that corresponds to other formatting that is in @htmlalignment
-	for my $i (0 .. $#htmlalignment) {
-		if ($htmlalignment[$i] =~ /\\color\s*\{\s*(\w*)[}!]/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] = 'color:' . $1 . '; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\\color\s*\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] = 'color:#' . $1 . '; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\\columncolor\s*\{\s*(\w*)[}!]/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] =
-				'background-color:' . $1 . '; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\\columncolor\s*\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] =
-				'background-color:#' . $1 . '; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\\bfseries$|\\bfseries\W/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] = 'font-weight:bold; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\\itshape$|\\itshape\W/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] = 'font-style:italic; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\\ttfamily$|\\ttfamily\W/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			$columnscss->[ $alignmentcolumns[$j] ] = 'font-family:monospace; ' . $columnscss->[ $alignmentcolumns[$j] ];
-		}
-		if ($htmlalignment[$i] =~ /\|\s*/) {
-			my $j = $i;
-			while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) { $j += 1; }
-			if ($j < $#htmlalignment) {
-				$columnscss->[ $alignmentcolumns[$j] ] =
-					"border-left:solid 1px; " . $columnscss->[ $alignmentcolumns[$j] ];
-			}
-			if (defined $alignmentcolumns[$j]) {
-				if ($alignmentcolumns[$j] != 0) {
-					$columnscss->[ $alignmentcolumns[$j] - 1 ] =
-						"border-right:solid 1px; " . $columnscss->[ $alignmentcolumns[$j] - 1 ];
-				}
-			}
-			if ($j == $#htmlalignment) {
-				if   ($j == $i) { $columnscss->[-1] = "border-right:solid 1px; " . $columnscss->[-1]; }
-				else            { $columnscss->[-1] = "border-left:solid 1px; " . $columnscss->[-1]; }
-			}
-		}
-
-	}
-
-	# translate individual cell's tex to css
-
-	for my $i (0 .. $#{$dataref}) {
-		for my $j (0 .. $numcols[$i]) {
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\color\s*\{\s*(\w*)[}!]/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'color:' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\color\s*\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'color:#' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\cellcolor\s*\{\s*(\w*)[}!]/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'background-color:' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\cellcolor\s*\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'background-color:#' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\bfseries$|\\bfseries\W/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'font-weight:bold; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\itshape$|\\itshape\W/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'font-style:italic; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-			if (${ $dataref->[$i][$j] }{tex} =~ /\\ttfamily$|\\ttfamily\W/) {
-				${ $dataref->[$i][$j] }{cellcss} = 'font-family:monospace; ' . ${ $dataref->[$i][$j] }{cellcss};
-			}
-		}
-	}
-
-	for my $i (0 .. $#columnalignments) { $alignmentcolumns[ $columnalignments[$i] ] = $i }
- # @alignmentcolumns is an array with one element per column, where the elements are each one of p{width}, r, c, l, or X
-
-	# append css to author's columnscss->[$i] that corresponds to the alignemnts in @alignmentcolumns
-
-	# parse tex alignment for individual cells to duplicate use in html
-	for my $i (0 .. $#{$dataref}) {
-		for my $j (0 .. $numcols[$i]) {
-			if (${ $dataref->[$i][$j] }{halign} ne '') {
-				my @htmlalignment = split(/(>\s*(??{$bracesregex})\s*|\|\s*|p\s*(??{$bracesregex})\s*|[rclX]\s*)/,
-					${ $dataref->[$i][$j] }{halign});
-				my @temp = ();
-				foreach (@htmlalignment) {
-					if ((defined $_) and ($_ ne '')) {
-						push(@temp, $_);
-					}
-				}
-				@htmlalignment = @temp;
-# @htmlalignment is now an array, where the entries are the parsed pieces of ${$dataref->[$i][$j]}{halign}; entries parsed by
-# >{commands}, pipes (for vertical rules), p{width}, r, c, l, or X. There should only be one of the actual alignment characters
-
-				my @columnalignments =
-					grep { $htmlalignment[$_] =~ /^p\s*(??{$bracesregex})\s*|^[rclX]\s*/ } 0 .. $#htmlalignment;
-# @columnalignments is an array, where the entries are the indices form @htmlalignment that actually deal with
-# alignment: p{width}, r, c, l, or X. This array should only have one entry (but structure of this whole section has been copied from above)
-
-				my @alignmentcolumns;
-				for my $k (0 .. $#columnalignments) { $alignmentcolumns[ $columnalignments[$k] ] = $k }
-		 # @alignmentcolumns is an array whose ith element is undefined unless the ith element of @htmlalignment was one
-		 # of p{width}, r, c, l, or X. Otherwise it is the index of the entry in @columnalignments that corresponds to
-		 # that alignment
-		 # Again, this should only have one entry.
-
-				for my $k (0 .. $#columnalignments) {
-					${ $dataref->[$i][$j] }{cellcss} = TeX_Alignment_to_CSS($htmlalignment[ $columnalignments[$k] ])
-						. ${ $dataref->[$i][$j] }{cellcss};
-				}
-				for my $k (0 .. $#htmlalignment) {
-					if ($htmlalignment[$k] =~ /\\color\s*\{\s*(\w*)[}!]/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} = 'color:' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\\color\s*\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} = 'color:#' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\\cellcolor\s*\{\s*(\w*)[}!]/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} =
-							'background-color:' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\\cellcolor\s*\[\s*HTML\s*\]\s*\{\s*(\w*)[}!]/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} =
-							'background-color:#' . $1 . '; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\\bfseries$|\\bfseries\W/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} = 'font-weight:bold; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\\itshape$|\\itshape\W/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} = 'font-style:italic; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\\ttfamily$|\\ttfamily\W/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						${ $dataref->[$i][$j] }{cellcss} = 'font-family:monospace; ' . ${ $dataref->[$i][$j] }{cellcss};
-					}
-					if ($htmlalignment[$k] =~ /\|\s*/) {
-						my $m = $k;
-						while (!defined($alignmentcolumns[$m]) && $m < $#htmlalignment) { $m += 1; }
-						if ($m < $#htmlalignment) {
-							${ $dataref->[$i][$j] }{cellcss} =
-								"border-left:solid 1px; " . ${ $dataref->[$i][$j] }{cellcss};
-						}
-						if (defined $alignmentcolumns[$m] && $alignmentcolumns[$m] != 0) {
-							${ $dataref->[$i][$j] }{cellcss} =
-								"border-right:solid 1px; " . ${ $dataref->[$i][$j] }{cellcss};
-						}
-						if ($m == $#htmlalignment) {
-							if ($m == $k) {
-								${ $dataref->[$i][$j] }{cellcss} =
-									"border-right:solid 1px; " . ${ $dataref->[$i][$j] }{cellcss};
-							} else {
-								${ $dataref->[$i][$j] }{cellcss} =
-									"border-left:solid 1px; " . ${ $dataref->[$i][$j] }{cellcss};
-							}
-						}
-					}
-
-				}
-			}
-		}
-	}
-
-	my $midrulescss = '';
-	if ($midrules == 1) { $midrulescss = 'border-top:solid 1px; ' }
-
-	my $table    = '';
-	my $ptxtable = '';
-	# build html and ptx strings for the table (which have structural similarities that distinguish them from tex)
-	if ($options{LaYoUt} != 1) {
-		$table    = '<TABLE style = "' . $tablecss . '">';
-		$ptxtable = "<tabular" . (($midrules) ? ' top="minor" bottom="minor"' : '') . ">\n";
-		$table .= '<colgroup>';
-		for my $i (0 .. $#{$columnscss}) {
-			$columnscss->[$i] = '' unless (defined($columnscss->[$i]));
-			$table .= '<col style = "' . $columnscss->[$i] . '">';
-		}
-		$table .= '</colgroup>';
-		if ($caption ne '') {
-			$table .= '<CAPTION style = "' . $captioncss . '">' . $caption . '</CAPTION>';
-			# Needs to be a better way to incorporate the caption into PTX output
-			# This way makes "captions" that extend past the table
-			#$ptxtable .= "<row>\n".'<cell colspan="'.$numcol.'">'.$caption.'</cell>'."\n</row>\n";
-		}
-		my $bodystarted = 0;
-		for my $i (0 .. $#{$dataref}) {
-			my $midrulecss = ($midrule[$i] == 1) ? 'border-bottom:solid 1px; ' : '';
-			if    ($i == $#{$dataref} and ($midrules == 1)) { $midrulescss .= 'border-bottom:solid 1px; '; }
-			if    ($headerrow[$i] == 1)                     { $table       .= '<THEAD>'; }
-			elsif (!$bodystarted)                           { $table       .= '<TBODY>'; $bodystarted = 1 }
-			$table    .= '<TR>';
-			$ptxtable .= "<row>\n";
-			for my $j (0 .. $numcols[$i]) {
-				my $colspan =
-					(${ $dataref->[$i][$j] }{colspan} eq '')
-					? ''
-					: 'colspan = "' . ${ $dataref->[$i][$j] }{colspan} . '" ';
-				if (uc(${ $dataref->[$i][$j] }{header}) eq 'TH') {
-					$table .= '<TH '
-						. $colspan
-						. 'style = "'
-						. $allcellcss
-						. $headercss
-						. $columnscss->[$j]
-						. $midrulecss
-						. $midrulescss
-						. $rowcss[$i]
-						. ${ $dataref->[$i][$j] }{cellcss} . '">'
-						. ${ $dataref->[$i][$j] }{data} . '</TH>';
-				} elsif (grep { uc(${ $dataref->[$i][$j] }{header}) eq $_ } ('CH', 'COLUMN', 'COL')) {
-					$table .= '<TH '
-						. $colspan
-						. 'scope = "col" style = "'
-						. $allcellcss
-						. $headercss
-						. $columnscss->[$j]
-						. $midrulecss
-						. $midrulescss
-						. $rowcss[$i]
-						. ${ $dataref->[$i][$j] }{cellcss} . '">'
-						. ${ $dataref->[$i][$j] }{data} . '</TH>';
-				} elsif (grep { uc(${ $dataref->[$i][$j] }{header}) eq $_ } ('RH', 'ROW')) {
-					$table .= '<TH '
-						. $colspan
-						. 'scope = "row" style = "'
-						. $allcellcss
-						. $headercss
-						. $columnscss->[$j]
-						. $midrulecss
-						. $midrulescss
-						. $rowcss[$i]
-						. ${ $dataref->[$i][$j] }{cellcss} . '">'
-						. ${ $dataref->[$i][$j] }{data} . '</TH>';
-				} elsif (uc(${ $dataref->[$i][$j] }{header}) eq 'TD') {
-					$table .= '<TD '
-						. $colspan
-						. 'style = "'
-						. $allcellcss
-						. $datacss
-						. $columnscss->[$j]
-						. $midrulecss
-						. $midrulescss
-						. $rowcss[$i]
-						. ${ $dataref->[$i][$j] }{cellcss} . '">'
-						. ${ $dataref->[$i][$j] }{data} . '</TD>';
-				} elsif (uc($headerrow[$i]) == 1) {
-					$table .= '<TH '
-						. $colspan
-						. 'scope = "col" style = "'
-						. $allcellcss
-						. $headercss
-						. $columnscss->[$j]
-						. $midrulecss
-						. $midrulescss
-						. $rowcss[$i]
-						. ${ $dataref->[$i][$j] }{cellcss} . '">'
-						. ${ $dataref->[$i][$j] }{data} . '</TH>';
-				} else {
-					$table .= '<TD '
-						. $colspan
-						. 'style = "'
-						. $allcellcss
-						. $datacss
-						. $columnscss->[$j]
-						. $midrulecss
-						. $midrulescss
-						. $rowcss[$i]
-						. ${ $dataref->[$i][$j] }{cellcss} . '">'
-						. ${ $dataref->[$i][$j] }{data} . '</TD>';
-				}
-				$ptxtable .= '<cell>' . ${ $dataref->[$i][$j] }{data} . '</cell>' . "\n";
-			}
-			$table    .= "</TR>";
-			$ptxtable .= "</row>\n";
-			if    ($headerrow[$i] == 1)                   { $table .= '</THEAD>'; }
-			elsif ($bodystarted and ($i == $#{$dataref})) { $table .= '</TBODY>'; }
-		}
-		$table    .= "</TABLE>";
-		$ptxtable .= "</tabular>";
-	}    # now if it is a Layout Table...
-	else {
-		$table = '<SECTION style = "display:table;' . $tablecss . '">';
-		for my $i (0 .. $#{$dataref}) {
-			if ($i == $#{$dataref} and ($midrules == 1)) { $midrulescss .= "border-bottom:solid 1px;"; }
-			my $midrulecss = ($midrule[$i] == 1) ? 'border-bottom:solid 1px; ' : '';
-			$table .= '<DIV style = "display:table-row;">';
-			for my $j (0 .. $numcols[$i]) {
-				$table .=
-					'<DIV style = "display:table-cell;'
-					. $allcellcss
-					. $columnscss->[$j]
-					. $midrulecss
-					. $midrulescss
-					. $rowcss[$i]
-					. ${ $dataref->[$i][$j] }{cellcss} . '">'
-					. ${ $dataref->[$i][$j] }{data}
-					. '</DIV>';
-			}
-			$table .= "</DIV>";
-		}
-		$table .= "</SECTION>";
-	}
-
-	#when \multicolumn{}{}{} is needed...
-	for my $i (0 .. $#{$dataref}) {
-		for my $j (0 .. $numcols[$i]) {
-			${ $dataref->[$i][$j] }{multicolumn} = '';
-			if ((${ $dataref->[$i][$j] }{halign} ne '') or (${ $dataref->[$i][$j] }{colspan} ne '')) {
-				${ $dataref->[$i][$j] }{multicolumn} = '\multicolumn{';
-				if (${ $dataref->[$i][$j] }{colspan} ne '') {
-					${ $dataref->[$i][$j] }{multicolumn} .= ${ $dataref->[$i][$j] }{colspan};
-				} else {
-					${ $dataref->[$i][$j] }{multicolumn} .= '1';
-				}
-				${ $dataref->[$i][$j] }{multicolumn} .= '}{';
-				if (${ $dataref->[$i][$j] }{halign} ne '') {
-					${ $dataref->[$i][$j] }{multicolumn} .= ${ $dataref->[$i][$j] }{halign};
-				} else {
-					${ $dataref->[$i][$j] }{multicolumn} .= 'c';
-				}
-				${ $dataref->[$i][$j] }{multicolumn} .= '}{';
-			}
-		}
-	}
-
-	my $textable = '';
-	# build tex string for the table
-	if ($options{LaYoUt} != 1) {
-		my ($begintabular, $endtabular) = ('\begin{tabular}', '\end{tabular}');
-		if ($texalignment =~ /X/) {
-			($begintabular, $endtabular) = ('\begin{tabularx}{' . $Xratio . '\linewidth}', '\end{tabularx}');
-		}
-		$textable = '\par\begin{minipage}{\linewidth}';
-		if ($center == 1) { $textable .= '\centering'; }
-		if ($caption ne '') {
-			$textable .=
-				'\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\captionof*{table}{' . $caption . '}';
-		}
-		$textable .= $begintabular . '{' . $texalignment . '}' . '\toprule';
-		for my $i (0 .. $#{$dataref}) {
-			if ($rowcolor[$i] ne '') { $textable .= '\rowcolor' . $rowcolor[$i]; }
-			for my $j (0 .. $numcols[$i])
-
-			{
-				if (grep { uc(${ $dataref->[$i][$j] }{header}) eq $_ } ('TH', 'CH', 'COLUMN', 'COL', 'RH', 'ROW')
-						or ($headerrow[$i] == 1) and !(uc(${ $dataref->[$i][$j] }{header}) eq 'TD'))
-				{
-					${ $dataref->[$i][$j] }{tex} = '\bfseries ' . ${ $dataref->[$i][$j] }{tex};
-				}
-
-				if (${ $dataref->[$i][$j] }{multicolumn} ne '') { $textable .= ${ $dataref->[$i][$j] }{multicolumn} }
-				$textable .=
-					${ $dataref->[$i][$j] }{texpre} . ' '
-					. ${ $dataref->[$i][$j] }{tex} . ' '
-					. ${ $dataref->[$i][$j] }{data} . ' '
-					. ${ $dataref->[$i][$j] }{texpost};
-				if (${ $dataref->[$i][$j] }{multicolumn} ne '') { $textable .= '}' }
-				$textable .= '&' unless ($j == $numcols[$i]);
-			}
-			$textable .= '\\\\';
-			if ($midrule[$i] == 1)                                                    { $textable .= '\midrule ' }
-			if ((($midrules == 1) or ($headerrow[$i] == 1)) and ($i != $#{$dataref})) { $textable .= '\midrule ' }
-		}
-		$textable .= '\bottomrule' . $endtabular;
-		$textable .= '\end{minipage}\par  \vspace{1pc}';
-	}    # and now if it is a Layout Table...
-	else {
-		my ($begintabular, $endtabular) = ('\begin{tabular}', '\end{tabular}');
-		if ($texalignment =~ /X/) {
-			($begintabular, $endtabular) = ('\begin{tabularx}{' . $Xratio . '\linewidth}', '\end{tabularx}');
-		}
-
-		$textable = ($center == 1) ? '\begin{center}' : '\begin{flushleft}';
-		$textable .= '{\renewcommand{\arraystretch}{2}';
-		$textable .= $begintabular . '{' . $texalignment . '}';
-		for my $i (0 .. $#{$dataref}) {
-			if ($rowcolor[$i] ne '') { $textable .= '\rowcolor' . $rowcolor[$i]; }
-			for my $j (0 .. $numcols[$i]) {
-				if (${ $dataref->[$i][$j] }{halign} ne '') {
-					$textable .= '\multicolumn{1}{' . ${ $dataref->[$i][$j] }{halign} . '}{';
-				}
-				$textable .=
-					${ $dataref->[$i][$j] }{tex} . ' '
-					. ${ $dataref->[$i][$j] }{texpre} . ' '
-					. ${ $dataref->[$i][$j] }{data} . ' '
-					. ${ $dataref->[$i][$j] }{texpost};
-				if (${ $dataref->[$i][$j] }{halign} ne '') { $textable .= '}' }
-				$textable .= '&' unless ($j == $numcols[$i]);
-			}
-			$textable .= '\\\\';
-			if ($midrule[$i] == 1)                         { $textable .= '\midrule ' }
-			if (($midrules == 1) and ($i != $#{$dataref})) { $textable .= '\midrule ' }
-		}
-		$textable .= $endtabular;
-		$textable .= '}';
-		if   ($center == 1) { $textable .= '\end{center}' }
-		else                { $textable .= '\end{flushleft}' }
-	}
-
-	MODES(
-		TeX  => $textable,
-		HTML => $table,
-		PTX  => $ptxtable,
-	);
+	my $userArray = shift;
+	my $dataArray = DataArray($userArray);
+	my $optsArray = OptionsArray($userArray);
+	my $colCount = ColumnCount($optsArray);
+	my $tableOpts = TableOptions($colCount, @_);
+	my $alignment = ParseAlignment($tableOpts->{texalignment});
+	TableEnvironment($dataArray, $optsArray, $colCount, $tableOpts, $alignment);
 }
-
-=pod
-
-Command for table to control layout
-
-Usage:  LayoutTable(...)
-	See usage for DataTable. The HTML output will use section and div boxes instead of HTML tabling elements
-	Anything having to do with headers, captions, and data cells no longer make sense (although 'data' is still
-	used as the key for cell contents).
-
-=cut
 
 sub LayoutTable {
-	my $dataref = shift;
-	if   ($main::displayMode eq 'PTX') { DataTable($dataref, @_); }
-	else                               { DataTable($dataref, LaYoUt => 1, @_); }
+	return DataTable(@_, LaYoUt => 1); 
 }
 
-sub TeX_Alignment_to_CSS {
-	my $alignmentstring = shift;
-	my $bracesregex     = qr/(\{(?>[^{}]|(?R))*\})/x;
-	# grabs outer level braces and their contents, including inner brace pairs
-	my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
-	# grabs contents of an outer level brace pair, including inner brace pairs
+# Make the outer table enovornment
+# Handle center, caption, horizontalrules, texalignment, Xratio
+# overall halign OK for tex, ptx but for html must be passed to cells
+# vertical rules from alingment OK
+# encase, rowheaders should be passed to cells
+# various css should be self-explanatory
+sub TableEnvironment {
+	my $dataArray = shift;
+	my $optsArray = shift;
+	my $colCount = shift;
+	my $tableOpts = shift;
+	my $alignment = shift;
+	my @alignment = @$alignment;
 
-	my $css = '';
-	if ($alignmentstring =~ /r\s*/) {
-		$css .= "text-align:right; white-space:nowrap; ";
-	} elsif ($alignmentstring =~ /c\s*/) {
-		$css .= "text-align:center; white-space:nowrap; ";
-	} elsif ($alignmentstring =~ /l\s*/) {
-		$css .= "text-align:left; white-space:nowrap; ";
-	} elsif ($alignmentstring =~ /X\s*/) {
-		$css .= "text-align:justify; white-space:normal; ";
-	} elsif ($alignmentstring =~ /p\s*\{((??{$bracecontentsregex}))\}\s*/) {
-		$css .= "text-align:justify; white-space:normal; width:" . $1 . "; ";
+	# determine if somewhere in the overall alignment, there are X columns
+	my $hasX = 0;
+	for my $align (@alignment) {
+		if ($align->{halign} eq 'X') {
+			$hasX = 1;
+			last;
+		}
 	}
-	return $css;
+
+	# determine if first row has top
+	my $top;
+	for my $x (@{$optsArray->[0]}) {
+		$top = $x->{top} if ($x->{top});
+	}
+
+	# get cols (only has some formatting specifications) and rows (the actual content)
+	my $cols = Cols($alignment, $tableOpts, $optsArray);
+	my $rows = Rows($dataArray, $optsArray, $colCount, $tableOpts, $alignment);
+
+	# TeX
+	my $tex = $rows;
+	my $tabulartype = $hasX ? 'tabularx' : 'tabular';
+	my $tabularwidth = $hasX ? "$tableOpts->{Xratio}\\linewidth" : '';
+	$tex = latexEnvironment($tex, $tabulartype, [$tabularwidth, $tableOpts->{texalignment}], ' ');
+	$tex = prefix($tex, '\centering') if $tableOpts->{center}; 
+	$tex = suffix($tex, "\\captionsetup{textfont={sc},belowskip=12pt,aboveskip=4pt}\\captionof*{table}{$tableOpts->{caption}}") if ($tableOpts->{caption});
+	$tex = latexEnvironment($tex, 'minipage', ['\linewidth']);
+	$tex = wrap($tex, '\par', '\par\vspace{1pc}');
+
+	# HTML
+	my $css = $tableOpts->{tablecss};
+	if ($hasX) {
+		$css .= css('width', $tableOpts->{Xratio}*100 . '%');
+	}	
+	$css .= css('border-left', getRuleCSS($alignment[0]->{left}));
+	$css .= css('margin', 'auto') if $tableOpts->{center};
+
+	my $html = $rows;
+	my $htmlcols = '';
+	$htmlcols = tag($cols, 'colgroup') unless ($cols =~ /^(<col>|\n)*$/ or $tableOpts->{LaYoUt});
+	$html = prefix($html, $htmlcols);
+	my $htmlcaption = tag($tableOpts->{caption}, 'caption', {style => $tableOpts->{captioncss}});
+	$html = prefix($html, $htmlcaption) unless $tableOpts->{LaYoUt};
+	if ($tableOpts->{LaYoUt}) {
+		$css .= css('display', 'table');
+		$css .= css('border-collapse', 'collapse');
+		$html = tag($html, 'div', {style => $css});
+	} else {
+		$html = tag($html, 'table', {style => $css});
+	}
+
+	# PTX
+	my $ptx = $cols;
+	$ptx = prefix($rows, $cols);
+	my $ptxleft = getPTXthickness($alignment[0]->{left});
+	my $ptxtop = ($tableOpts->{horizontalrules}) ? 'major' : '';
+	$ptxtop = getPTXthickness($top) if $top;
+	my $ptxwidth;
+	my $ptxmargins;
+	if ($hasX) {
+		$ptxwidth = $tableOpts->{Xratio}*100;
+		my $leftmargin = ($tableOpts->{center}) ? (100 - $ptxwidth)/2 : 0;
+		my $rightmargin = 100 - $ptxwidth - $leftmargin;
+		$ptxmargins = "${leftmargin}% ${rightmargin}%";
+		$ptxwidth .= '%';
+	} elsif (!$tableOpts->{center}) {
+		$ptxwidth = '100%';
+		$ptxmargins = '0% 0%';
+	}
+	my $ptxbottom = ($tableOpts->{horizontalrules}) ? 'minor' : '';
+	$ptx = tag($ptx, 'tabular', {valign => $tableOpts->{valign}, width => $ptxwidth, margins => $ptxmargins, left => $ptxleft, top => $ptxtop, bottom => $ptxbottom});
+	# We fake a caption as a following tabular
+	my $ptxcaption = '';
+	if ($tableOpts->{caption}) {
+		$ptxcaption = $tableOpts->{caption};
+		$ptxcaption = tag($ptxcaption, 'cell');
+		$ptxcaption = tag($ptxcaption, 'row');
+		my $ptxcapwidth = '';
+		if ($hasX) {
+			$ptxcapwidth = $tableOpts->{Xratio}*100 . '%';
+		} else {
+			$ptxcapwidth = '50%';
+		}
+		$ptxcapcol = tag('', 'col', {width => $ptxcapwidth});
+		$ptxcaption = prefix($ptxcaption, $ptxcapcol);
+		$ptxcaption = tag($ptxcaption, 'tabular', {width => $ptxwidth, margins => $ptxmargins});
+	}
+	$ptx = suffix($ptx, $ptxcaption);
+
+	MODES(
+		TeX => $tex,
+		HTML => $html,
+		PTX => $ptx,
+	);
+
 }
+
+
+sub Cols {
+	my $alignment = shift;
+	my $tableOpts = shift;
+	my $optsArray = shift;
+	my $columnscss = $tableOpts->{columnscss};
+	my @html;
+	my @ptx;
+	my @alignment = @$alignment;
+	my $leftend = shift(@alignment);
+
+	for my $i (0..$#alignment) {
+		my $align = $alignment[$i];
+		# determine if this column has paragraph cells
+		my $width = '';
+		for my $y (@$optsArray) {
+			if ($y->[$i]->{halign} =~ /^p\{([^}]*?)\}/) {
+				$width = $1;
+			};
+		}
+
+		# HTML
+		my $htmlright = '';
+		$htmlright .= css('border-right', 'solid 2px') if ($tableOpts->{rowheaders} && $i == 0);
+		$htmlright .= css('border-right', getRuleCSS($align->{right}));
+
+		$htmlcolcss = $columnscss->[$i];
+		if ($align->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
+			$htmlcolcss .= css('background-color', ($1 ? '#' : '') . $2);
+		}
+
+		my $html = tag('', 'col', {style => "${htmlright}${htmlcolcss}"});
+		push(@html, $html);
+
+		# PTX
+		my $ptxhalign = '';
+		$ptxhalign = 'center' if ($align->{halign} eq 'c');
+		$ptxhalign = 'right' if ($align->{halign} eq 'r');
+		my $ptxright = '';
+		$ptxright = getPTXthickness($align->{right});
+		my $ptxwidth = '';
+		$ptxwidth = getWidthPercent($align->{width}) if $align->{width};
+		$ptxwidth = ($tableOpts->{Xratio} / ($#alignment + 1) * 100) . '%' if ($align->{halign} eq 'X');
+		$ptxwidth = getWidthPercent($width) if $width;
+		my $ptx = tag('', 'col', {header => ($tableOpts->{rowheaders} && $i == 0) ? 'yes' : '', halign => $ptxhalign, right => $ptxright, width => $ptxwidth});
+		push(@ptx, $ptx);
+	}
+
+	$return = MODES(
+		HTML => join("\n", @html),
+		PTX => join("\n", @ptx)
+	);
+
+	return $return;
+
+}
+
+sub Rows {
+	my $dataArray = shift;
+	my $optsArray = shift;
+	my $colCount = shift;
+	my $tableOpts = shift;
+	my $alignment = shift;
+	my @data = @$dataArray;
+	
+	my @tex;
+	my @htmlhead;
+	my @htmlbody;
+	my $stillinhtmlhead = 1;
+	my @ptx;
+	for my $i (0..$#data) {
+		my $rowData = $data[$i];
+		my $rowOpts = $optsArray->[$i];
+		my $row = Row($rowData, $rowOpts, $tableOpts, $alignment);
+		# establish if this row has certain things
+		# non falsy last values are used
+		my $bottom = 0;
+		my $top = 0;
+		my $rowcolor = '';
+		my $headerrow = '';
+		my $valign = '';
+		for my $x (@$rowOpts) {
+			$bottom = $x->{bottom} if ($x->{bottom});
+			$top = $x->{top} if ($x->{top} && $i == 0);
+			$rowcolor = $x->{rowcolor} if ($x->{rowcolor});
+			$headerrow = 'yes' if ($x->{headerrow});
+			$valign = $x->{valign} if ($x->{valign});
+		}
+
+		# TeX
+		my $tex = $row;
+		# separator argument is space to avoid PGML catcode manipulation issues
+		$tex = prefix($tex, "\\rowcolor{$rowcolor}", ' ') if ($rowcolor =~ /^[^{]+$/);
+		$tex = prefix($tex, "\\rowcolor$rowcolor", ' ') if ($rowcolor =~ /^(\[HTML\])?\{[^}]+\}/);
+		$tex = prefix($tex, "\\toprule", ' ') if ($top || ($i == 0 && $tableOpts->{horizontalrules})); 
+		$tex = suffix($tex, "\\\\", ' ') unless ($i == $#data);
+		$tex = suffix($tex, "\\midrule", ' ') if ($i < $#data && ($bottom || $tableOpts->{horizontalrules}) || $headerrow);
+		$tex = suffix($tex, "\\\\\\bottomrule", ' ') if ($i == $#data && ($bottom or $tableOpts->{horizontalrules}));
+		push(@tex, $tex);
+
+		# HTML
+		my $css = '';
+		for my $x (@$rowOpts) {
+			$css .= $x->{rowcss} if  $x->{rowcss};
+		}
+		if ($rowcolor =~ /(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('background-color', ($1 ? '#' : '') . $2);
+		} else {
+			$css .= css('background-color', $rowcolor) if $rowcolor;
+		}
+		$css .= css('border-top', 'solid 3px') if ($i == 0 && $tableOpts->{horizontalrules});
+		$css .= css('border-top', getRuleCSS($top));
+		$css .= css('border-bottom', 'solid 1px') if ($i < $#data && $tableOpts->{horizontalrules});
+		$css .= css('border-bottom', 'solid 3px') if ($i == $#data && $tableOpts->{horizontalrules});
+		$css .= css('border-bottom', getRuleCSS($bottom));
+		$css .= css('vertical-align', $valign);
+		my $html;
+		if ($tableOpts->{LaYoUt}) {
+			$css .= css('display', 'table-row');
+			$html = tag($row, 'div', {style => $css});
+			push(@htmlbody, $html);
+		} else {
+			$html = tag($row, 'tr', {style => $css});
+			if ($stillinhtmlhead && $headerrow) {
+				push(@htmlhead, $html);
+			} else {
+				$stillinhtmlhead = 0;
+				push(@htmlbody, $html);
+			}
+		}
+
+		# PTX
+		my $ptx .= $row;
+		my $ptxbottom = '';
+		$ptxbottom = 'minor' if ($i < $#data && $tableOpts->{horizontalrules});
+		$ptxbottom = 'major' if ($i == $#data && $tableOpts->{horizontalrules});
+		$ptxbottom = getPTXthickness($bottom) if $bottom;
+		my $ptxleft = '';
+		$ptxleft = 'minor' if ($rowOpts->[0]->{halign} =~ /^\s*\|/);
+		$ptxleft = 'medium' if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|/);
+		$ptxleft = 'major' if ($rowOpts->[0]->{halign} =~ /^\s*\|\s*\|\s*\|/);
+		if ($rowOpts->[0]->{halign} =~ /^(?:\s|\|)*!{\s*\\vrule\s+width\s+([^}]*?)\s*}/) {
+			$ptxleft = 'minor' if ($1);
+			$ptxleft = 'minor' if ($1 == '0.04em');
+			$ptxleft = 'medium' if ($1 == '0.07em');
+			$ptxleft = 'major' if ($1 == '0.11em');
+		};
+		$ptx = tag($ptx, 'row', {left => $ptxleft, valign => $valign, header => $headerrow, bottom => $ptxbottom});
+		push(@ptx, $ptx);
+	}
+
+	my $htmlout;
+	if ($tableOpts->{LaYoUt}) {
+		$htmlout = join("\n", @htmlbody)
+	} else {
+		my $htmlvalign = '';
+		$htmlvalign = $tableOpts->{valign} unless ($tableOpts->{valign} eq 'middle');
+		$htmlout = tag(join("\n", @htmlbody), 'tbody',  {style => css('vertical-align', $htmlvalign)});
+		$htmlout = prefix($htmlout, tag(join("\n", @htmlhead), 'thead', {style => css('vertical-align', $htmlvalign).css('border-bottom', 'solid 2px')})) if (@htmlhead);
+	}
+	
+	$return = MODES(
+		TeX => join(" ", @tex),
+		HTML => $htmlout,
+		PTX => join("\n", @ptx),
+	);
+
+	return $return;
+
+}
+
+sub Row {
+	my $rowData = shift;
+	my $rowOpts = shift;
+	my $tableOpts = shift;
+	my $alignment = shift;
+	my @alignment = @$alignment;
+	my $leftend = shift(@alignment);
+	my @data = @$rowData;
+	my $headerrow = '';
+	my $valign = '';
+	for my $x (@$rowOpts) {
+		$headerrow = 'yes' if ($x->{headerrow});
+		$valign = $x->{valign} if ($x->{valign});
+	}
+
+	my @tex;
+	my @html;
+	my @ptx;
+	for my $i (0..$#data) {
+		my $cellOpts = $rowOpts->[$i];
+		my $cell = $data[$i];
+
+		# TeX
+		my $tex = $cell;
+		$tex = prefix($tex, $cellOpts->{tex});
+		$tex = wrap($tex, @{$tableOpts->{encase}}) unless $cellOpts->{noencase};
+		$tex = wrap($tex, $cellOpts->{texpre}, $cellOpts->{texpost});
+		$tex = prefix($tex, '\bfseries') if ($tableOpts->{rowheaders} and $i == 0 or $headerrow or $cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i);
+		if ($cellOpts->{colspan} > 1 or $cellOpts->{halign} or $valign or ($tableOpts->{valign} && $tableOpts->{valign} ne 'top')) {
+			my $columntype = $cellOpts->{halign};
+			$columntype = $alignment[$i]->{halign} // 'l' unless $columntype;
+			$columntype = 'p{' . $tableOpts->{Xratio} / ($#data + 1) . "\\linewidth}" if ($columntype eq 'X');
+			$columntype = "p{$alignment[$i]->{width}}" if ($alignment[$i]->{width});
+			$columntype =~ s/^p/m/ if ($valign eq 'middle');
+			$columntype =~ s/^p/b/ if ($valign eq 'bottom');
+			$columntype =~ s/^p/m/ if ($tableOpts->{valign} eq 'middle');
+			$columntype =~ s/^p/b/ if ($tableOpts->{valign} eq 'bottom');
+			$tex = latexCommand('multicolumn', [$cellOpts->{colspan}, $columntype, $tex]);
+		}
+		$tex = suffix($tex, '&', ' ') unless ($i == $#data);
+		push(@tex, $tex);
+
+		# HTML
+		my $t = 'td';
+		my $scope = '';
+		$t = 'th' and $scope = 'row' if ($i == 0 && $tableOpts->{rowheaders});
+		$t = 'th' and $scope = 'col' if ($headerrow);
+		$t = 'th' if ($cellOpts->{header} =~ /^(th|rh|ch|col|column|row)$/i);
+		$scope = 'row' if ($cellOpts->{header} =~ /^(rh|row)$/i);
+		$scope = 'col' if ($cellOpts->{header} =~ /^(ch|col|column)$/i);
+		$t = 'td' and $scope = '' if ($cellOpts->{header} =~ /^td$/i);
+		my $css = '';
+		# col level
+		$css .= css('text-align', 'center') if ($alignment[$i]->{halign} eq 'c');
+		$css .= css('text-align', 'right') if ($alignment[$i]->{halign} eq 'r');
+		$css .= css('width', $alignment[$i]->{width}) if ($alignment[$i]->{width});
+		$css .= css('font-weight', 'bold') if ($alignment[$i]->{tex} =~ /\\bfseries/);
+		$css .= css('font-style', 'italic') if ($alignment[$i]->{tex} =~ /\\itshape/);
+		$css .= css('font-family', 'monospace') if ($alignment[$i]->{tex} =~ /\\ttfamily/);
+		if ($alignment[$i]->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('color', ($1 ? '#' : '') . $2);
+		}
+		# cell level
+		$css .= $cellOpts->{cellcss};
+		if ($cellOpts->{halign} =~ /^([|\s]*\|)/ && $i == 0) {
+			my $count = $1 =~ tr/\|//;
+			$css .= css('border-left', "solid ${count}px");
+		}
+		if ($cellOpts->{halign} =~ /^(\s\|)*!{\\vrule\s+width\s+([^}]*?)}/ && $i == 0) {
+			$css .= css('border-left', "solid $2");
+		};
+		if ($cellOpts->{halign} =~ /(\|[|\s]*)$/) {
+			my $count = $1 =~ tr/\|//;
+			$css .= css('border-right', "solid ${count}px");
+		}
+		if ($cellOpts->{halign} =~ /!{\\vrule\s+width\s+([^}]*?)}\s*$/) {
+			$css .= css('border-right', "solid $1");
+		};
+		$css .= css('text-align', 'left') if ($cellOpts->{halign} =~ /^l/);
+		$css .= css('text-align', 'center') if ($cellOpts->{halign} =~ /^c/);
+		$css .= css('text-align', 'right') if ($cellOpts->{halign} =~ /^r/);
+		$css .= css('text-align', 'left') if ($cellOpts->{halign} =~ /^p/);
+		$css .= css('width', $1) if ($cellOpts->{halign} =~ /^p{([^}]*?)}/);
+		$css .= css('font-weight', 'bold') if ($cellOpts->{tex} =~ /\\bfseries/);
+		$css .= css('font-style', 'italic') if ($cellOpts->{tex} =~ /\\itshape/);
+		$css .= css('font-family', 'monospace') if ($cellOpts->{tex} =~ /\\ttfamily/);
+		if ($cellOpts->{tex} =~ /\\cellcolor(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('background-color', ($1 ? '#' : '') . $2);
+		}
+		if ($cellOpts->{tex} =~ /\\color(\[HTML\])?{(.*?)[}!]/) {
+			$css .= css('color', ($1 ? '#' : '') . $2);
+		}
+		$css .= $tableOpts->{allcellcss};
+		$css .= $tableOpts->{headercss} if ($t eq 'th');
+		$css .= $tableOpts->{datacss} if ($t eq 'td');
+		my $html = $cell;
+		$html = wrap($cell, @{$tableOpts->{encase}}) unless $cellOpts->{noencase};
+		if ($tableOpts->{LaYoUt}) {
+			$css .= css('display', 'table-cell');
+			my $cellvalign = $tableOpts->{valign};
+			$cellvalign = $valign if ($valign);
+			$css = css('vertical-align', $cellvalign) . $css;
+			$css = css('padding', '12pt') . $css;
+			if ($alignment[$i]->{tex} =~ /\\columncolor(\[HTML\])?{(.*?)[}!]/) {
+				$css = css('background-color', ($1 ? '#' : '') . $2) . $css;
+			}
+			$css = css('border-right', getRuleCSS($alignment[$i]->{right})) . $css;
+			$html = tag($html, 'div', {style => $css});
+		} else {
+			$css = css('padding', '0pt 6pt') . $css;
+			$html = tag($html, $t, {style => $css, scope => $scope, colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : ''});
+		}
+		push(@html, $html);
+
+		# PTX
+		my $ptx = $cell;
+		$ptx = wrap($ptx, @{$tableOpts->{encase}}) unless $cellOpts->{noencase};
+		# space following p is intentional hack to prevent p from scrubbing by PTX cleanup 
+		$ptx = wrap($ptx, '<p >', '</p >') if ($alignment[$i]->{width} or $alignment[$i]->{halign} eq 'X' or $cellOpts->{halign} =~ /^p/);
+		my $ptxhalign = '';
+		$ptxhalign = 'center' if ($cellOpts->{halign} =~ /c/);
+		$ptxhalign = 'right' if ($cellOpts->{halign} =~ /r/);
+		my $ptxright = '';
+		$ptxright = 'minor' if ($cellOpts->{halign} =~ /\|\s*$/);
+		$ptxright = 'medium' if ($cellOpts->{halign} =~ /\|\s*\|\s*$/);
+		$ptxright = 'major' if ($cellOpts->{halign} =~ /\|\s*\|\s*\|\s*$/);
+		if ($cellOpts->{halign} =~ /!{\s*\\vrule\s+width\s+([^}]*?)\s*}\s*$/) {
+			$ptxright = 'minor' if ($1);
+			$ptxright = 'minor' if ($1 == '0.04em');
+			$ptxright = 'medium' if ($1 == '0.07em');
+			$ptxright = 'major' if ($1 == '0.11em');
+		};
+		$ptx = tag($ptx, 'cell', {halign => $ptxhalign, colspan => ($cellOpts->{colspan} > 1) ? $cellOpts->{colspan} : '', right => $ptxright});
+		push(@ptx, $ptx);
+	}
+
+	$return = MODES(
+		TeX => join(" ", @tex),
+		HTML => join("\n", @html),
+		PTX => join("\n", @ptx),
+	);
+
+	return $return;
+
+
+}
+
+# Takes the original nested array and returns a simplified version with only the content 
+# Also returns the true column count, accounting for colspan
+sub DataArray {
+	my $originalArrayRef = shift;
+	my @originalArray = @$originalArrayRef;
+	my $lastRowIndex = $#originalArray;
+	my @outArray;
+	for my $i (0..$lastRowIndex) {
+		my @outRow;
+		my $originalRowRef = $originalArray[$i];
+		my @originalRow = @$originalRowRef;
+		my $lastColIndex = $#originalRow;
+		for my $j (0..$lastColIndex) {
+			my $originalCell = $originalRow[$j];
+			my $outCell;
+			if (ref($originalCell) eq 'HASH') {
+				$outCell = $originalCell->{'data'};
+			} elsif (ref($originalCell) eq 'ARRAY') {
+				$outCell = $originalCell->[0];
+			} else {
+				$outCell = $originalCell;
+			}
+			$outRow[$j] = $outCell;
+		}
+		my $outRowRef = \@outRow;
+		$outArray[$i] = $outRowRef;
+	}
+	$outArrayRef = \@outArray;
+	return $outArrayRef;
+}
+
+# Takes the original nested array and returns a simplified version with only the options as a hash 
+sub OptionsArray {
+	my %supportedOptions = (
+		halign => '',
+		header => '',
+		tex => '',
+		noencase => 0,
+		colspan => 1,
+		cellcss => '',
+		texpre => '',
+		texpost => '',
+		rowcolor => '',
+		rowcss => '',
+		headerrow => '',
+		top => 0,
+		bottom => 0,
+		valign => '',
+	);
+	my $originalArrayRef = shift;
+	my @originalArray = @$originalArrayRef;
+	my $lastRowIndex = $#originalArray;
+	my @outArray;
+	for my $i (0..$lastRowIndex) {
+		my @outRow;
+		my $originalRowRef = $originalArray[$i];
+		my @originalRow = @$originalRowRef;
+		my $lastColIndex = $#originalRow;
+		for my $j (0..$lastColIndex) {
+			my $originalCell = $originalRow[$j];
+			my $outCell;
+			my %outHash = %supportedOptions;
+			if (ref($originalCell) eq 'HASH') {
+				for my $key (keys(%supportedOptions)) {
+					$outHash{$key} = $originalCell->{$key} if defined($originalCell->{$key});
+				}
+				# convenience
+				$outHash{tex} .= '\bfseries' if ($originalCell->{b});
+				$outHash{tex} .= '\itshape' if ($originalCell->{i});
+				$outHash{tex} .= '\ttfamily' if ($originalCell->{m});
+				$outHash{texpre} = $outHash{texpre} . $originalCell->{texencase}->[0] if $originalCell->{texencase};
+				$outHash{texpost} = $originalCell->{texencase}->[1] . $outHash{texpost} if $originalCell->{texencase};
+				# legacy misnomers
+				$outHash{bottom} = $originalCell->{midrule} if (defined($originalCell->{midrule}) && !$outHash{bottom});
+			} elsif (ref($originalCell) eq 'ARRAY') {
+				my @originalOptions = (@$originalCell);
+				my $data = shift(@originalOptions);
+				my %originalOptions = @originalOptions;
+				for my $key (keys(%supportedOptions)) {
+					$outHash{$key} = $originalOptions{$key} if defined($originalOptions{$key});
+				}
+				# convenience
+				$outHash{tex} .= '\bfseries' if ($originalOptions{b});
+				$outHash{tex} .= '\itshape' if ($originalOptions{i});
+				$outHash{tex} .= '\ttfamily' if ($originalOptions{m});
+				$outHash{texpre} = $outHash{texpre} . $originalOptions{texencase}->[0] if $originalOptions{texencase};
+				$outHash{texpost} = $originalOptions{texencase}->[1] . $outHash{texpost} if $originalOptions{texencase};
+				# legacy misnomers
+				$outHash{bottom} = $originalOptions{midrule} if (defined($originalOptions{midrule}) && !$outHash{bottom});
+			}
+			# clean up
+			# remove any left vertical rule specifications from halign
+			if ($j > 0 && $outHash{halign} =~ /((?<!\w)[lcrp](?!\w)\s*(\{[^}]*?\})?(\||!\{[^}]*?\}|\s)*)/) {$outHash{halign} = $1};
+
+			$outCell = \%outHash;
+			$outRow[$j] = $outCell;
+		}
+		my $outRowRef = \@outRow;
+		$outArray[$i] = $outRowRef;
+	}
+	$outArrayRef = \@outArray;
+	return $outArrayRef;
+}
+
+sub ColumnCount {
+	my $optsRef = shift;
+	my @options = @$optsRef;
+	my $lastRowIndex = $#options;
+	my $colCount = 0;
+	for my $i (0..$lastRowIndex) {
+		my $rowOptsRef = $options[$i];
+		my @rowOpts = @$rowOptsRef;
+		my $lastColIndex = $#rowOpts;
+		my $thisRowColCount = 0;
+		for my $j (0..$lastColIndex) {
+			$thisRowColCount += $rowOpts[$j]->{colspan};
+		}
+		$colCount = max($colCount, $thisRowColCount);
+	}
+	return $colCount;
+}
+
+sub TableOptions {
+	my $colCount = shift;
+	my %supportedOptions = (
+		center => 1,
+		caption => '',
+		horizontalrules => 0,
+		texalignment => join('', ('c') x $colCount),
+		Xratio => 0.97,
+		encase => ['',''],
+		rowheaders => 0,
+		tablecss => '',
+		captioncss => '',
+		columnscss => [('') x $colCount],
+		datacss => '',
+		headercss => '',
+		allcellcss => '',
+		valign => 'top',
+		LaYoUt => 0,
+	);
+	%outHash = %supportedOptions;
+	my %userOptions = @_;
+	for my $key (keys(%supportedOptions)) {
+		$outHash{$key} = $userOptions{$key} if defined($userOptions{$key});
+	}
+	# special user shortcut
+	$outHash{texalignment} = $userOptions{align} if (defined($userOptions{align}) && !$userOptions{texalignment});
+	# legacy misnomers
+	$outHash{horizontalrules} = $userOptions{midrules} if (defined($userOptions{midrules}) && !$outHash{horizontalrules});
+	return \%outHash;
+}
+
+sub ParseAlignment {
+	my $alignment = shift;
+	# first we parse things like *{20}{...} to expand them
+	my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;
+	while ($alignment =~ /$pattern/) {
+		my @captured = ($alignment =~ /$pattern/);
+		my $replaceWith = $captured[1] x $captured[0];
+		$alignment =~ s/$pattern/$replaceWith/;
+	}
+
+	my @align = ();
+	# 0th entry is only for possible left border
+	# other entries have only right borders,
+	# the actual alignment is r, c, l, X, or p
+	# explicit width vertical rules from !{...}
+	# latex directives from >{...}
+	# we make an array of the tokens of type:
+	# r, c, l, X, |, !{...}, p{...}, >{...}
+	# this is complicated because of potential nested brackets
+	my @tokens = ();
+	my $bracesregex = qr/(\{(?>[^{}]|(?R))*\})/x;
+	my $bracecontentsregex = qr/((?>[^{}]|(??{$bracesregex}))*)/x;
+	# . at the end is to ensure we are whittling down $alignment at least a little
+	my $tokenspattern = qr/^([rclX\|]\s*|[!p>]\s*\{((??{$bracecontentsregex}))\}\s*|.)/;
+
+	$align[0] = {left => 0};
+	$leftpattern = '^\s*(\|\s*|!\s*\{\s*\\vrule\s+width\s+([^}]*?)\})';
+	while ($alignment =~ /$leftpattern/) {
+		my $token = $1;
+		if ($token =~ /^\|/) {
+			# this counts how many | we have
+			$align[0]->{left} = 0 unless ($align[$i]->{left} && $align[$i]->{left} =~ /\d+/);
+			$align[0]->{left} += 1;
+		} elsif ($token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/) {
+			$align[0]->{left} = $1;
+		}
+		$alignment =~ s/$leftpattern//;
+	}
+	# now that leftmost vertical rule tokens taken care of, get all the other tokens
+	while ($alignment) {
+		my $token = ($alignment =~ /$tokenspattern/)[0];
+		$alignment =~ s/$tokenspattern//;
+		push(@tokens, $token);
+	}
+	# now run through tokens and grow @align
+	# index for @align
+	my $i = 1;
+	# $j is index for @tokens
+	for my $j (0..$#tokens) {
+		my $token = $tokens[$j];
+		my $next = $tokens[$j+1] // '';
+		if ($token =~ /^([lcrX])/) {
+			$align[$i]->{halign} = $1;
+			$align[$i]->{valign} = 'top' if ($1 eq 'X');
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^\|/) {
+			# this counts how many | we have
+			$align[$i]->{right} = 0 unless ($align[$i]->{right} && $align[$i]->{right} =~ /\d+/);
+			$align[$i]->{right} += 1;
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^!\s*\{\s*\\vrule\s+width\s+([^}]*?)\}/) {
+			# for this style of vertical rule we store the width instead of a small positive integer
+			$align[$i]->{right} = $1;
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^p\{((??{$bracecontentsregex}))\}\s*/) {
+			$align[$i]->{halign} = 'l';
+			# record top alignment, but could be overwritten by row valign
+			$align[$i]->{valign} = 'top';
+			$align[$i]->{width} = $1;
+			$i++ unless ($next =~ /^[|!]/);
+		} elsif ($token =~ /^>\s*\{((??{$bracecontentsregex}))\}/) {
+			$align[$i]->{tex} = $1;
+			# could parse these further for color identification, etc
+		}
+	}
+	
+	return \@align;
+
+
+}
+
+sub latexEnvironment {
+	my $inside = shift;
+	my $environment = shift;
+	my $options = shift;
+	my $separator = shift // "\n";
+	my $return = "\\begin{$environment}";
+	for my $x (@$options) {
+		$return .= "{$x}" if ($x ne '');
+	}
+	$return .= "$separator$inside$separator";
+	$return .= "\\end{$environment}";
+	return $return;
+}
+
+sub latexCommand {
+	my $command = shift;
+	my $arguments = shift;
+	my $return = "\\$command";
+	for my $x (@$arguments) {
+		$return .= "{$x}" if ($x ne '');
+	}
+	$return .= " ";
+	return $return;
+}
+
+sub wrap {
+	my $center = shift;
+	my $left = shift;
+	my $right = shift;
+	my $separator = shift // "\n";
+	return $center unless ($left || $right);
+	return "$left$separator$center" unless $right;
+	return "$center$separator$right" unless $left;
+	return "$left$separator$center$separator$right";
+}
+
+sub prefix {
+	my $center = shift;
+	my $left = shift;
+	my $separator = shift // "\n";
+	return join("$separator",($left, $center)) if ($left ne '');
+	return $center;
+}
+
+sub suffix {
+	my $center = shift;
+	my $right = shift;
+	my $separator = shift // "\n";
+	return join("$separator",($center, $right)) if ($right ne '');
+	return $center;
+}
+
+sub css {
+	my $property = shift;
+	my $value = shift;
+	return ($value) ? "$property:$value;" : '';
+}
+
+sub tag {
+	my $inner = shift;
+	my $name = shift;
+	my $attributes = shift;
+	my $return = "<$name";
+	for my $x (lex_sort(keys %$attributes)) {
+		$return .= qq( $x="$attributes->{$x}") if ($attributes->{$x} ne '');
+	}
+	if ($inner) {
+		$return .= ">\n";
+		$return .= $inner;
+		$return .= "\n</$name>";
+	} else {
+		$return .= '>' unless ($main::displayMode eq 'PTX');
+		$return .= '/>' if ($main::displayMode eq 'PTX');
+	}
+	return $return;
+}
+
+sub getRuleCSS {
+	my $input = shift;
+	my $output = '';
+	if ($input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/) {
+		$output = "solid $1px" if $1;
+	} elsif ($input) {
+		$output = "solid $input" if $input;
+	}
+	return $output;
+}
+
+sub getPTXthickness {
+	my $input = shift;
+	my $output = '';
+	if ($input == 1) {
+		$output = "minor";
+	} elsif ($input == 2) {
+		$output = "medium";
+	} elsif ($input >= 3) {
+		$output = "major";
+	} elsif ($input eq '0.04em') {
+		$output = 'minor';
+	} elsif ($input eq '0.07em') {
+		$output = 'medium';
+	} elsif ($input eq '0.11em') {
+		$output = 'major';
+	} elsif ($input) {
+		$output = "minor";
+	}
+	return $output;
+}
+
+sub getWidthPercent {
+	my $absWidth = shift;
+	my $x = 0;
+	my $unit = 'cm';
+	if ($absWidth =~ /^(\.\d+|\d+\.?\d*)\s*(\w+)/) {
+		$x = $1;
+		$unit = $2;
+	}
+	my %convert_to_cm = (
+		'pt' => 1/864 * 249/250 * 12 * 2.54,
+		'mm' => 1/10,
+		'cm' => 1,
+		'in' => 2.54,
+		'ex' => 0.15132,
+		'em' => 0.35146,
+		'mu' => 0.35146/8,
+		'sp' => 1/864 * 249/250 * 12 * 2.54 / 65536,
+		'bp' => 2.54/72,
+		'dd' => 1/864 * 249/250 * 12 * 2.54 * 1238 /1157,
+		'pc' => 1/864 * 249/250 * 12 * 2.54 * 12,
+		'cc' => 1/864 * 249/250 * 12 * 2.54 * 1238 /1157 * 12,
+		'px' => 2.54/72,
+	);
+	return (int($x * $convert_to_cm{$unit} / (6.25 * 2.54) * 10000)/100) . '%';
+}
+
 
 1;

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -192,11 +192,7 @@ sub LayoutTable {
 # encase, rowheaders should be passed to cells
 # various css should be self-explanatory
 sub TableEnvironment {
-	my $dataArray = shift;
-	my $optsArray = shift;
-	my $colCount = shift;
-	my $tableOpts = shift;
-	my $alignment = shift;
+	my ($dataArray, $optsArray, $colCount, $tableOpts, $alignment) = @_;
 	my @alignment = @$alignment;
 
 	# determine if somewhere in the overall alignment, there are X columns
@@ -298,9 +294,7 @@ sub TableEnvironment {
 
 
 sub Cols {
-	my $alignment = shift;
-	my $tableOpts = shift;
-	my $optsArray = shift;
+	my ($alignment, $tableOpts, $optsArray) = @_;
 	my $columnscss = $tableOpts->{columnscss};
 	my @html;
 	my @ptx;
@@ -354,11 +348,7 @@ sub Cols {
 }
 
 sub Rows {
-	my $dataArray = shift;
-	my $optsArray = shift;
-	my $colCount = shift;
-	my $tableOpts = shift;
-	my $alignment = shift;
+	my ($dataArray, $optsArray, $colCount, $tableOpts, $alignment) = @_;
 	my @data = @$dataArray;
 	
 	my @tex;
@@ -468,10 +458,7 @@ sub Rows {
 }
 
 sub Row {
-	my $rowData = shift;
-	my $rowOpts = shift;
-	my $tableOpts = shift;
-	my $alignment = shift;
+	my ($rowData, $rowOpts, $tableOpts, $alignment) = @_;
 	my @alignment = @$alignment;
 	my $leftend = shift(@alignment);
 	my @data = @$rowData;
@@ -647,6 +634,9 @@ sub DataArray {
 
 # Takes the original nested array and returns a simplified version with only the options as a hash 
 sub OptionsArray {
+	my $originalArrayRef = shift;
+	my @originalArray = @$originalArrayRef;
+	my $lastRowIndex = $#originalArray;
 	my %supportedOptions = (
 		halign => '',
 		header => '',
@@ -663,9 +653,6 @@ sub OptionsArray {
 		bottom => 0,
 		valign => '',
 	);
-	my $originalArrayRef = shift;
-	my @originalArray = @$originalArrayRef;
-	my $lastRowIndex = $#originalArray;
 	my @outArray;
 	for my $i (0..$lastRowIndex) {
 		my @outRow;
@@ -849,10 +836,8 @@ sub ParseAlignment {
 }
 
 sub latexEnvironment {
-	my $inside = shift;
-	my $environment = shift;
-	my $options = shift;
-	my $separator = shift // "\n";
+	my ($inside, $environment, $options, $separator) = @_;
+	$separator = "\n" unless ($separator);
 	my $return = "\\begin{$environment}";
 	for my $x (@$options) {
 		$return .= "{$x}" if ($x ne '');
@@ -863,8 +848,7 @@ sub latexEnvironment {
 }
 
 sub latexCommand {
-	my $command = shift;
-	my $arguments = shift;
+	my ($command, $arguments) = @_;
 	my $return = "\\$command";
 	for my $x (@$arguments) {
 		$return .= "{$x}" if ($x ne '');
@@ -874,10 +858,8 @@ sub latexCommand {
 }
 
 sub wrap {
-	my $center = shift;
-	my $left = shift;
-	my $right = shift;
-	my $separator = shift // "\n";
+	my ($center, $left, $right, $separator) = @_;
+	$separator = "\n" unless ($separator);
 	return $center unless ($left || $right);
 	return "$left$separator$center" unless $right;
 	return "$center$separator$right" unless $left;
@@ -885,31 +867,26 @@ sub wrap {
 }
 
 sub prefix {
-	my $center = shift;
-	my $left = shift;
-	my $separator = shift // "\n";
+	my ($center, $left, $separator) = @_;
+	$separator = "\n" unless ($separator);
 	return join("$separator",($left, $center)) if ($left ne '');
 	return $center;
 }
 
 sub suffix {
-	my $center = shift;
-	my $right = shift;
-	my $separator = shift // "\n";
+	my ($center, $right, $separator) = @_;
+	$separator = "\n" unless ($separator);
 	return join("$separator",($center, $right)) if ($right ne '');
 	return $center;
 }
 
 sub css {
-	my $property = shift;
-	my $value = shift;
+	my ($property, $value) = @_;
 	return ($value) ? "$property:$value;" : '';
 }
 
 sub tag {
-	my $inner = shift;
-	my $name = shift;
-	my $attributes = shift;
+	my ($inner, $name, $attributes) = @_;
 	my $return = "<$name";
 	for my $x (lex_sort(keys %$attributes)) {
 		$return .= qq( $x="$attributes->{$x}") if ($attributes->{$x} ne '');

--- a/t/output_macros/niceTables.t
+++ b/t/output_macros/niceTables.t
@@ -1,0 +1,147 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - factorial
+
+Test factorials.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use lib "$ENV{PG_ROOT}/lib";
+
+# This is needed for PGsort.
+# use WeBWorK::PG::Translator;
+
+loadMacros('niceTables.pl', 'PGstandard.pl');
+
+use Data::Dumper;
+
+my $tab           = DataTable([ [ 1, 2, 3 ], [ 4, 5, 6 ] ]);
+my $std_pad       = 'padding:0pt 6pt;';
+my $talign_center = 'text-align:center;';
+
+is $tab, qq{<table style="margin:auto;">
+<caption>
+<tbody style="vertical-align:top;">
+<tr>
+<td style="$std_pad$talign_center">
+1
+</td>
+<td style="$std_pad$talign_center">
+2
+</td>
+<td style="$std_pad$talign_center">
+3
+</td>
+</tr>
+<tr>
+<td style="$std_pad$talign_center">
+4
+</td>
+<td style="$std_pad$talign_center">
+5
+</td>
+<td style="$std_pad$talign_center">
+6
+</td>
+</tr>
+</tbody>
+</table>}, 'test for a basic table with no options';
+
+my $non_centered_tab = DataTable([ [ 1, 2, 3 ], [ 4, 5, 6 ] ], center => 0);
+
+is $non_centered_tab, qq{<table>
+<caption>
+<tbody style="vertical-align:top;">
+<tr>
+<td style="$std_pad$talign_center">
+1
+</td>
+<td style="$std_pad$talign_center">
+2
+</td>
+<td style="$std_pad$talign_center">
+3
+</td>
+</tr>
+<tr>
+<td style="$std_pad$talign_center">
+4
+</td>
+<td style="$std_pad$talign_center">
+5
+</td>
+<td style="$std_pad$talign_center">
+6
+</td>
+</tr>
+</tbody>
+</table>}, 'test for a basic table that is not centered';
+
+my $tab_with_caption = DataTable([ [ 1, 2, 3 ], [ 4, 5, 6 ] ], caption => 'This is the caption');
+
+is $tab_with_caption, qq{<table style="margin:auto;">
+<caption>
+This is the caption
+</caption>
+<tbody style="vertical-align:top;">
+<tr>
+<td style="$std_pad$talign_center">
+1
+</td>
+<td style="$std_pad$talign_center">
+2
+</td>
+<td style="$std_pad$talign_center">
+3
+</td>
+</tr>
+<tr>
+<td style="$std_pad$talign_center">
+4
+</td>
+<td style="$std_pad$talign_center">
+5
+</td>
+<td style="$std_pad$talign_center">
+6
+</td>
+</tr>
+</tbody>
+</table>}, 'test for a basic table with caption';
+
+my $tab_with_hor_rules = DataTable([ [ 1, 2, 3 ], [ 4, 5, 6 ] ], horizontalrules => 1);
+
+is $tab_with_hor_rules, qq{<table style="margin:auto;">
+<caption>
+<tbody style="vertical-align:top;">
+<tr style="border-top:solid 3px;border-bottom:solid 1px;">
+<td style="$std_pad$talign_center">
+1
+</td>
+<td style="$std_pad$talign_center">
+2
+</td>
+<td style="$std_pad$talign_center">
+3
+</td>
+</tr>
+<tr style="border-bottom:solid 3px;">
+<td style="$std_pad$talign_center">
+4
+</td>
+<td style="$std_pad$talign_center">
+5
+</td>
+<td style="$std_pad$talign_center">
+6
+</td>
+</tr>
+</tbody>
+</table>}, 'test for a basic table with horizontal rules';
+
+done_testing();


### PR DESCRIPTION
Here's a sample test file for nice tables.  Unfortunately it seems the best way to check is to do string comparison.  And I only added a few tests, but gets started a few things:
-  to run the test from the PG_ROOT directory run `prove -v t/output_macros/niceTables.t`
-  I've noticed that the output of the table if there is no caption, just has an empty caption block.  Either drop the <caption> or close it too.
-  I cleaned up some warnings that occurred mainly from undefined variables. 
- I also moved the `PGsort` function from the `Translator.pm` file, so tests with sorting can be run without loading that directory.  Talking with people, probably that used to be in `Translator.pm` because once it needed to be outside of Safe, (due to calling the `sort` function), however this version of `PGsort` doesn't call that function. Seems like it works fine.
- If you run `prove t/macros/load_macros.t` (which loads every macro), there are more warnings for `niceTables.pl`.  I cleaned up some of those, but we should clean the rest up too. 