### PR TITLE
Add a TO_JSON method to Value objects.

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -274,7 +274,7 @@ sub stringify_hash {
 		my $ref = ref($self->{$key});
 		next if !$ref;
 		if ($ref eq "HASH" or $ref eq "ARRAY") {
-			$self->{$key} = JSON->new->utf8->allow_unknown->allow_blessed->encode($self->{$key});
+			$self->{$key} = JSON->new->utf8->allow_unknown->convert_blessed->allow_blessed->encode($self->{$key});
 		} else {
 			$self->{$key} = "$self->{$key}";
 		}

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -1035,6 +1035,11 @@ sub string {
 	return $open . join($comma, @coords) . $close;
 }
 
+# This is called by JSON->encode when convert_blessed is true to convert this value object into a string.
+sub TO_JSON {
+	return shift->string;
+}
+
 =head4 ->TeX
 
 	Usage: $mathObj->TeX()

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -463,8 +463,7 @@ sub cmp_defaults {
 		list_type         => 'selection',
 		requireParenMatch => 0,
 		implicitList      => 0,
-		correct_choices   => $self->data,
-		correct_values    => [ map {"$_"} $self->value ]
+		correct_choices   => $self->data
 	);
 }
 


### PR DESCRIPTION
This method is essentially an alias of the `string` method that Value objects already have.  TO_JSON is called by JSON->encode when convert_blessed is true.  So if you call
JSON->convert_blessed->encode($value) where $value is a Value object or where $value contains an array entry or hash key that is a Value object, these Value objects will be properly converted into a string in the output.

@Alex-Jordan:  I was going to go with your idea of adding the `correct_value` to the `cmp_defaults` of parserCheckboxList.pl.  But I just don't really like the idea of adding another key to the answer hash that is really the same thing as something already there in a slightly weaker form.  In addition, I think the `TO_JSON` value method has more implications toward future clean up of math objects.  Please consider this instead.  This makes it so that the existing `correct_choices` will work the same as the `correct_values` key that I removed here once outside of the safe zone, but will still have the full math object structure while still in the safe zone.