### PR TITLE
Only add the incorrect coloring and icon to text or MathQuill inputs that are non empty

### DIFF
--- a/htdocs/js/InputColor/color.js
+++ b/htdocs/js/InputColor/color.js
@@ -17,7 +17,10 @@
 					if (!radioGroups[input.name]) radioGroups[input.name] = [];
 					radioGroups[input.name].push(input);
 				} else {
-					input.classList.add(type);
+					if (input.type.toLowerCase() === 'text') {
+						if (type === 'correct' || input.value !== '') input.classList.add(type);
+					} else
+						input.classList.add(type);
 				}
 			});
 

--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -501,7 +501,9 @@
 			if (answerLabel.includes(tableLink.dataset.answerId)) {
 				if (tableLink.parentNode.classList.contains('ResultsWithoutError'))
 					answerQuill.classList.add('correct');
-				else answerQuill.classList.add('incorrect');
+				else {
+					if (answerQuill.input.value !== '') answerQuill.classList.add('incorrect');
+				}
 			}
 
 			// Make a click on the results table link give focus to the mathquill answer box.


### PR DESCRIPTION
This just skips adding the incorrect class to those inputs in the javascript.  This only applies to text or MathQuill inputs.  Radio buttons, dropdowns, and checkboxes are not affected at this point.