### PR TITLE
Add javascript to animate expanding and collapsing the solution/hint details and button icon.

### DIFF
--- a/htdocs/js/Problem/details-accordion.js
+++ b/htdocs/js/Problem/details-accordion.js
@@ -1,0 +1,65 @@
+(() => {
+	class Accordion {
+		constructor(details) {
+			this.details = details;
+			this.summary = details.querySelector('summary');
+			this.content = details.querySelector('.accordion-body');
+			this.animation = null;
+			this.isClosing = false;
+			this.isExpanding = false;
+			this.summary.addEventListener('click', (e) => this.onClick(e));
+		}
+
+		onClick(e) {
+			e.preventDefault();
+			this.details.style.overflow = 'hidden';
+			if (this.isClosing || !this.details.open) this.open();
+			else if (this.isExpanding || this.details.open) this.shrink();
+		}
+
+		shrink() {
+			this.isClosing = true;
+			this.details.classList.add('closing');
+			if (this.animation) this.animation.cancel();
+			this.animation = this.details.animate(
+				{ height: [`${this.details.offsetHeight}px`, `${this.summary.offsetHeight}px`] },
+				{ duration: 200, easing: 'ease-in-out' }
+			);
+			this.animation.addEventListener('finish', () => this.onAnimationFinish(false), { once: true });
+			this.animation.addEventListener('cancel', () => (this.isClosing = false), { once: true });
+		}
+
+		open() {
+			this.details.style.height = `${this.details.offsetHeight}px`;
+			this.details.open = true;
+			window.requestAnimationFrame(() => this.expand());
+		}
+
+		expand() {
+			this.isExpanding = true;
+			if (this.animation) this.animation.cancel();
+			this.animation = this.details.animate(
+				{
+					height: [
+						`${this.details.offsetHeight}px`,
+						`${this.summary.offsetHeight + this.content.offsetHeight}px`
+					]
+				},
+				{ duration: 400, easing: 'ease-out' }
+			);
+			this.animation.addEventListener('finish', () => this.onAnimationFinish(true), { once: true });
+			this.animation.addEventListener('cancel', () => (this.isExpanding = false), { once: true });
+		}
+
+		onAnimationFinish(isOpen) {
+			this.details.open = isOpen;
+			this.details.classList.remove('closing');
+			this.animation = null;
+			this.isClosing = false;
+			this.isExpanding = false;
+			this.details.style.height = this.details.style.overflow = '';
+		}
+	}
+
+	document.querySelectorAll('.solution > details,.hint > details').forEach((details) => new Accordion(details));
+})();

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -33,13 +33,18 @@
 	}
 
 	/* Problem elements */
-	label, input[type=text], select, textarea {
+	label,
+	input[type='text'],
+	select,
+	textarea {
 		font-weight: normal;
 		line-height: 18px;
 		width: auto;
 	}
 
-	select, textarea, input[type=text] {
+	select,
+	textarea,
+	input[type='text'] {
 		display: inline-block;
 		padding: 4px 6px;
 		margin-bottom: 0;
@@ -50,17 +55,21 @@
 		background-color: white;
 	}
 
-	textarea, input[type=text] {
-		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	textarea,
+	input[type='text'] {
+		font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	}
 
-	input[type=text] {
+	input[type='text'] {
 		height: 30px;
 		font-size: 14px;
 		line-height: 20px;
 	}
 
-	select, input[type=text], input[type=radio], input[type=checkbox] {
+	select,
+	input[type='text'],
+	input[type='radio'],
+	input[type='checkbox'] {
 		&.correct {
 			border-color: rgba(81, 153, 81, 0.8); /* green */
 			outline: 0;
@@ -72,11 +81,12 @@
 			border-color: rgba(191, 84, 84, 0.8); /* red */
 			outline: 0;
 			box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px 2px rgba(191, 84, 84, 0.6);
-			color:inherit;
+			color: inherit;
 		}
 	}
 
-	input[type=text], span.mq-editable-field {
+	input[type='text'],
+	span.mq-editable-field {
 		background-size: 20px auto;
 		background-position: right 4px center;
 		background-repeat: no-repeat;
@@ -92,14 +102,15 @@
 		}
 	}
 
-	input[type=radio] {
+	input[type='radio'] {
 		margin-right: 0.25rem;
 	}
 
 	select {
 		cursor: pointer;
 
-		&[multiple], &[size] {
+		&[multiple],
+		&[size] {
 			height: auto;
 		}
 	}
@@ -108,7 +119,10 @@
 		max-width: 100%;
 	}
 
-	input[type=text], input[type=radio], textarea, select {
+	input[type='text'],
+	input[type='radio'],
+	textarea,
+	select {
 		&:focus {
 			border-color: rgba(82, 168, 236, 0.8);
 			outline: 0;
@@ -118,9 +132,40 @@
 
 	.pg-table {
 		text-align: center;
-		thead, tbody, tfoot, tr, td, th {
+		thead,
+		tbody,
+		tfoot,
+		tr,
+		td,
+		th {
 			padding: 0.25rem;
 			border: 1px solid black;
+		}
+	}
+
+	.solution,
+	.hint {
+		details.accordion-item:not([open]) .accordion-button {
+			background-color: var(--bs-accordion-bg);
+		}
+
+		details.accordion-item:not([open]):last-of-type .accordion-button {
+			border-bottom-right-radius: var(--bs-accordion-border-radius);
+			border-bottom-left-radius: var(--bs-accordion-border-radius);
+		}
+
+		details.accordion-item:not([open]) .accordion-button::after {
+			background-image: var(--bs-accordion-btn-active-icon);
+			transform: unset;
+		}
+
+		details.accordion-item[open] .accordion-button::after {
+			background-image: var(--bs-accordion-btn-icon);
+			transform: var(--bs-accordion-btn-icon-transform);
+		}
+
+		details.accordion-item.closing .accordion-button::after {
+			transform: var(--bs-accordion-btn-icon-transition);
 		}
 	}
 }
@@ -179,7 +224,8 @@ table.attemptResults {
 		border-bottom-right-radius: 4px;
 	}
 
-	td, th {
+	td,
+	th {
 		border-style: inset;
 		border-width: 1px;
 		text-align: center;
@@ -230,7 +276,8 @@ table.attemptResults {
 		height: 100%;
 	}
 
-	a, a span {
+	a,
+	a span {
 		color: #038;
 		text-decoration: none;
 
@@ -240,7 +287,9 @@ table.attemptResults {
 	}
 }
 
-div, label, span {
+div,
+label,
+span {
 	&.ResultsWithoutError {
 		color: #0f5132; /* Dark Green */
 		background-color: #8f8; /* Light Green */

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -33,18 +33,13 @@
 	}
 
 	/* Problem elements */
-	label,
-	input[type='text'],
-	select,
-	textarea {
+	label, input[type=text], select, textarea {
 		font-weight: normal;
 		line-height: 18px;
 		width: auto;
 	}
 
-	select,
-	textarea,
-	input[type='text'] {
+	select, textarea, input[type=text] {
 		display: inline-block;
 		padding: 4px 6px;
 		margin-bottom: 0;
@@ -55,21 +50,17 @@
 		background-color: white;
 	}
 
-	textarea,
-	input[type='text'] {
-		font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	textarea, input[type=text] {
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	}
 
-	input[type='text'] {
+	input[type=text] {
 		height: 30px;
 		font-size: 14px;
 		line-height: 20px;
 	}
 
-	select,
-	input[type='text'],
-	input[type='radio'],
-	input[type='checkbox'] {
+	select, input[type=text], input[type=radio], input[type=checkbox] {
 		&.correct {
 			border-color: rgba(81, 153, 81, 0.8); /* green */
 			outline: 0;
@@ -81,12 +72,11 @@
 			border-color: rgba(191, 84, 84, 0.8); /* red */
 			outline: 0;
 			box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px 2px rgba(191, 84, 84, 0.6);
-			color: inherit;
+			color:inherit;
 		}
 	}
 
-	input[type='text'],
-	span.mq-editable-field {
+	input[type=text], span.mq-editable-field {
 		background-size: 20px auto;
 		background-position: right 4px center;
 		background-repeat: no-repeat;
@@ -102,15 +92,14 @@
 		}
 	}
 
-	input[type='radio'] {
+	input[type=radio] {
 		margin-right: 0.25rem;
 	}
 
 	select {
 		cursor: pointer;
 
-		&[multiple],
-		&[size] {
+		&[multiple], &[size] {
 			height: auto;
 		}
 	}
@@ -119,10 +108,7 @@
 		max-width: 100%;
 	}
 
-	input[type='text'],
-	input[type='radio'],
-	textarea,
-	select {
+	input[type=text], input[type=radio], textarea, select {
 		&:focus {
 			border-color: rgba(82, 168, 236, 0.8);
 			outline: 0;
@@ -132,40 +118,9 @@
 
 	.pg-table {
 		text-align: center;
-		thead,
-		tbody,
-		tfoot,
-		tr,
-		td,
-		th {
+		thead, tbody, tfoot, tr, td, th {
 			padding: 0.25rem;
 			border: 1px solid black;
-		}
-	}
-
-	.solution,
-	.hint {
-		details.accordion-item:not([open]) .accordion-button {
-			background-color: var(--bs-accordion-bg);
-		}
-
-		details.accordion-item:not([open]):last-of-type .accordion-button {
-			border-bottom-right-radius: var(--bs-accordion-border-radius);
-			border-bottom-left-radius: var(--bs-accordion-border-radius);
-		}
-
-		details.accordion-item:not([open]) .accordion-button::after {
-			background-image: var(--bs-accordion-btn-active-icon);
-			transform: unset;
-		}
-
-		details.accordion-item[open] .accordion-button::after {
-			background-image: var(--bs-accordion-btn-icon);
-			transform: var(--bs-accordion-btn-icon-transform);
-		}
-
-		details.accordion-item.closing .accordion-button::after {
-			transform: var(--bs-accordion-btn-icon-transition);
 		}
 	}
 }
@@ -224,8 +179,7 @@ table.attemptResults {
 		border-bottom-right-radius: 4px;
 	}
 
-	td,
-	th {
+	td, th {
 		border-style: inset;
 		border-width: 1px;
 		text-align: center;
@@ -276,8 +230,7 @@ table.attemptResults {
 		height: 100%;
 	}
 
-	a,
-	a span {
+	a, a span {
 		color: #038;
 		text-decoration: none;
 
@@ -287,9 +240,7 @@ table.attemptResults {
 	}
 }
 
-div,
-label,
-span {
+div, label, span {
 	&.ResultsWithoutError {
 		color: #0f5132; /* Dark Green */
 		background-color: #8f8; /* Light Green */

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -395,11 +395,12 @@ sub ADD_JS_FILE {
 # Some problems use jquery-ui still, and so the requestor should also load the js for that if those problems are used,
 # although those problems should also be rewritten to not use jquery-ui.
 sub load_js() {
-	ADD_JS_FILE('js/InputColor/color.js',    0, { defer => undef });
-	ADD_JS_FILE('js/Base64/Base64.js',       0, { defer => undef });
-	ADD_JS_FILE('js/Knowls/knowl.js',        0, { defer => undef });
-	ADD_JS_FILE('js/ImageView/imageview.js', 0, { defer => undef });
-	ADD_JS_FILE('js/Essay/essay.js',         0, { defer => undef });
+	ADD_JS_FILE('js/InputColor/color.js',          0, { defer => undef });
+	ADD_JS_FILE('js/Base64/Base64.js',             0, { defer => undef });
+	ADD_JS_FILE('js/Knowls/knowl.js',              0, { defer => undef });
+	ADD_JS_FILE('js/Problem/details-accordion.js', 0, { defer => undef });
+	ADD_JS_FILE('js/ImageView/imageview.js',       0, { defer => undef });
+	ADD_JS_FILE('js/Essay/essay.js',               0, { defer => undef });
 
 	if ($envir{useMathQuill}) {
 		ADD_JS_FILE('node_modules/mathquill/dist/mathquill.js', 0, { defer => undef });

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1190,10 +1190,14 @@ sub SOLUTION {
 				class => 'accordion-item',
 				tag(
 					'summary',
-					class => 'accordion-button',
+					class => 'accordion-button collapsed',
 					tag('div', class => 'accordion-header user-select-none', SOLUTION_HEADING())
 					)
-					. tag('div', class => 'accordion-body', $solution_body)
+					. tag(
+						'div',
+						class => 'accordion-collapse collapse',
+						tag('div', class => 'accordion-body', $solution_body)
+					)
 			)
 		));
 	} elsif ($displayMode =~ /TeX/) {
@@ -1228,10 +1232,14 @@ sub HINT {
 				class => 'accordion-item',
 				tag(
 					'summary',
-					class => 'accordion-button',
+					class => 'accordion-button collapsed',
 					tag('div', class => 'accordion-header user-select-none', HINT_HEADING())
 					)
-					. tag('div', class => 'accordion-body', $hint_body)
+					. tag(
+						'div',
+						class => 'accordion-collapse collapse',
+						tag('div', class => 'accordion-body', $hint_body)
+					)
 			)
 		));
 	} elsif ($displayMode =~ /TeX/) {

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1184,16 +1184,16 @@ sub SOLUTION {
 	if ($displayMode =~ /HTML/) {
 		TEXT(tag(
 			'div',
-			class => 'solution accordion border-bottom-0',
+			class => 'solution accordion my-3',
 			tag(
 				'details',
-				class => 'accordion-item border-bottom-0',
+				class => 'accordion-item',
 				tag(
 					'summary',
 					class => 'accordion-button',
 					tag('div', class => 'accordion-header user-select-none', SOLUTION_HEADING())
 					)
-					. tag('div', class => 'accordion-body border-bottom', $solution_body)
+					. tag('div', class => 'accordion-body', $solution_body)
 			)
 		));
 	} elsif ($displayMode =~ /TeX/) {
@@ -1222,16 +1222,16 @@ sub HINT {
 	if ($displayMode =~ /HTML/) {
 		TEXT(tag(
 			'div',
-			class => 'hint accordion border-bottom-0',
+			class => 'hint accordion my-3',
 			tag(
 				'details',
-				class => 'accordion-item border-bottom-0',
+				class => 'accordion-item',
 				tag(
 					'summary',
 					class => 'accordion-button',
 					tag('div', class => 'accordion-header user-select-none', HINT_HEADING())
 					)
-					. tag('div', class => 'accordion-body border-bottom', $hint_body)
+					. tag('div', class => 'accordion-body', $hint_body)
 			)
 		));
 	} elsif ($displayMode =~ /TeX/) {

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -105,6 +105,7 @@ is(
 			{ file => 'js/InputColor/color.js',                   external => 0, attributes => { defer => undef } },
 			{ file => 'js/Base64/Base64.js',                      external => 0, attributes => { defer => undef } },
 			{ file => 'js/Knowls/knowl.js',                       external => 0, attributes => { defer => undef } },
+			{ file => 'js/Problem/details-accordion.js',          external => 0, attributes => { defer => undef } },
 			{ file => 'js/ImageView/imageview.js',                external => 0, attributes => { defer => undef } },
 			{ file => 'js/Essay/essay.js',                        external => 0, attributes => { defer => undef } },
 			{ file => 'node_modules/mathquill/dist/mathquill.js', external => 0, attributes => { defer => undef } },


### PR DESCRIPTION
This is probably not exactly what you had in mind, but gives the best result in my opinion.  This leverages the bootstrap collapse activated via javascript.  As such we do not need to add our own styles.  The bootstrap collapse styles are used instead.

Note this is in two commits that are really independent of each other.  The first commit is basically what is done in https://christianoliff.com/blog/building-a-bootstrap-accordion-with-the-details/summary-html-tags/ with a few tweaks.  However, I saw some issues with that approach.  So the second commit was added with the approach described above.  The advantage is that bootstrap developers have already worked out the styles and everything, so just using that is much simpler.

Note that both cases are actually using pretty much the same techniques if you delve down to where the css and javascript is actually implemented for the two approaches.