### PR TITLE
Change badges to buttons and remove inline javascript.

### DIFF
--- a/htdocs/js/Problem/generic.js
+++ b/htdocs/js/Problem/generic.js
@@ -1,4 +1,6 @@
 (() => {
+	// Details accordions
+
 	const setupAccordion = (accordion) => {
 		const collapseEl = accordion.querySelector('.collapse');
 		const button = accordion.querySelector('summary.accordion-button');
@@ -38,4 +40,11 @@
 		});
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
+
+	// Image long description dismiss buttons
+	for (const dismissButton of document.querySelectorAll('.image-details-dismiss')) {
+		dismissButton.addEventListener('click', () =>
+			dismissButton.parentElement?.parentElement?.parentElement?.removeAttribute('open')
+		);
+	}
 })();

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -215,11 +215,13 @@
 		border-top-right-radius: 4px;
 		z-index: 10;
 	}
-}
 
-.image-details-dismiss {
-	display: block;
-	float: right;
+	.image-details-btn {
+		--bs-btn-padding-y: 0.1rem;
+		--bs-btn-padding-x: 0.35rem;
+		--bs-btn-font-size: 0.65rem;
+		--bs-btn-border-radius: 0.375rem;
+	}
 }
 
 /* rtl:raw:

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -381,12 +381,12 @@ sub ADD_JS_FILE {
 # although those problems should also be rewritten to not use jquery-ui.
 sub load_js() {
 
-	ADD_JS_FILE('js/Feedback/feedback.js',         0, { defer => undef });
-	ADD_JS_FILE('js/Base64/Base64.js',             0, { defer => undef });
-	ADD_JS_FILE('js/Knowls/knowl.js',              0, { defer => undef });
-	ADD_JS_FILE('js/Problem/details-accordion.js', 0, { defer => undef });
-	ADD_JS_FILE('js/ImageView/imageview.js',       0, { defer => undef });
-	ADD_JS_FILE('js/Essay/essay.js',               0, { defer => undef });
+	ADD_JS_FILE('js/Feedback/feedback.js',   0, { defer => undef });
+	ADD_JS_FILE('js/Base64/Base64.js',       0, { defer => undef });
+	ADD_JS_FILE('js/Knowls/knowl.js',        0, { defer => undef });
+	ADD_JS_FILE('js/Problem/generic.js',     0, { defer => undef });
+	ADD_JS_FILE('js/ImageView/imageview.js', 0, { defer => undef });
+	ADD_JS_FILE('js/Essay/essay.js',         0, { defer => undef });
 
 	if ($envir{useMathQuill}) {
 		ADD_JS_FILE('node_modules/@openwebwork/mathquill/dist/mathquill.js', 0, { defer => undef });

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2867,7 +2867,7 @@ sub image {
 					title => 'details',
 					tag(
 						'span',
-						class         => 'badge badge-info bg-secondary',
+						class         => 'image-details-btn btn btn-sm btn-secondary fw-bold',
 						'aria-hidden' => 'true',
 						maketext('image description')
 					)
@@ -2877,13 +2877,15 @@ sub image {
 						id    => 'LONG-DESCRIPTION-ID',
 						class => 'image-details-content bg-white py-2 px-3 my-2 border',
 						shift(@desc_list)
-						. tag('br')
 						. tag(
-							'button',
-							class   => 'image-details-dismiss badge badge-info bg-secondary',
-							type    => 'button',
-							onclick => "this.parentElement.parentElement.removeAttribute('open')",
-							maketext('Close image description')
+							'div',
+							class => 'd-flex justify-content-end mt-2',
+							tag(
+								'button',
+								class   => 'image-details-dismiss btn btn-sm btn-secondary',
+								type    => 'button',
+								maketext('Close image description')
+							)
 						)
 					)
 			);

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -104,12 +104,12 @@ is(
 			{ file => 'js/MathQuill/mqeditor.css',                              external => undef }
 		],
 		extra_js_files => [
-			{ file => 'js/Feedback/feedback.js',         external => 0, attributes => { defer => undef } },
-			{ file => 'js/Base64/Base64.js',             external => 0, attributes => { defer => undef } },
-			{ file => 'js/Knowls/knowl.js',              external => 0, attributes => { defer => undef } },
-			{ file => 'js/Problem/details-accordion.js', external => 0, attributes => { defer => undef } },
-			{ file => 'js/ImageView/imageview.js',       external => 0, attributes => { defer => undef } },
-			{ file => 'js/Essay/essay.js',               external => 0, attributes => { defer => undef } },
+			{ file => 'js/Feedback/feedback.js',   external => 0, attributes => { defer => undef } },
+			{ file => 'js/Base64/Base64.js',       external => 0, attributes => { defer => undef } },
+			{ file => 'js/Knowls/knowl.js',        external => 0, attributes => { defer => undef } },
+			{ file => 'js/Problem/generic.js',     external => 0, attributes => { defer => undef } },
+			{ file => 'js/ImageView/imageview.js', external => 0, attributes => { defer => undef } },
+			{ file => 'js/Essay/essay.js',         external => 0, attributes => { defer => undef } },
 			{
 				file       => 'node_modules/@openwebwork/mathquill/dist/mathquill.js',
 				external   => 0,


### PR DESCRIPTION
Buttons are better for interactive elements than badges.

To facilitate making it easier to make general javascript for PG the `details-accordion.js` file is renamed to `generic.js`, and that file is used for the inline javascript in this case.  Unfortunately `problem.js` cannot be used due to a conflict with the webwork2 `problem.js` file.

Also, the dismiss button inside the details is now in a display flex justify-end div instead of using `float`.