### PR TITLE
Suggestions for #1272.

### DIFF
--- a/macros/answers/Generic.pl
+++ b/macros/answers/Generic.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-Generic.pl - provide some generic answer checkers.
+Generic.pl - Provide some generic answer checkers.
 
 =head1 DESCRIPTION
 

--- a/macros/answers/PGasu.pl
+++ b/macros/answers/PGasu.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-PGasu.pl -- A set of macros for old school answer checkers.
+PGasu.pl - A set of macros for old school answer checkers.
 
 =head1 DESCRIPTION
 

--- a/macros/answers/PGfunctionevaluators.pl
+++ b/macros/answers/PGfunctionevaluators.pl
@@ -1,6 +1,4 @@
 
-## Note: this should be decprecated
-
 =head1 NAME
 
 PGfunctionevaluators.pl - Macros that generate function answer evaluators.

--- a/macros/answers/PGmiscevaluators.pl
+++ b/macros/answers/PGmiscevaluators.pl
@@ -7,6 +7,11 @@ PGmiscevaluators.pl - Some miscellaneous answer macros.
 
 Currently contains answer evaluators for radio buttons and checkboxes.
 
+
+The L<parserRadioButtons.pl> and L<parserCheckboxList.pl> macros that manage
+display and checking of radio-button and checkbox based answers. It is
+recommended that you use those, instead of using the methods in this file.
+
 =cut
 
 BEGIN { strict->import; }
@@ -22,7 +27,7 @@ $correctAnswer is a string containing the names of the correct boxes, e.g.
 "ACD". Note that this means that individual checkbox names can only be one
 character. Internally, this is largely the same as unordered_cs_str_cmp().
 
-Note: see L<parserCheckboxList.pl> for an alternative to this.
+Note: See L<parserCheckboxList.pl> for an alternative to this.
 
 =cut
 
@@ -89,7 +94,7 @@ $correctAnswer	is a string containing the name of the correct radio button,
 e.g. "Choice1". This is case sensitive and whitespace sensitive, so the correct
 answer must match the name of the radio button exactly.
 
-Note: see L<parserRadioButtons.pl> for an alternative to this.
+Note: See L<parserRadioButtons.pl> for an alternative to this.
 
 =cut
 

--- a/macros/answers/answerCustom.pl
+++ b/macros/answers/answerCustom.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-answerCustom.pl - provides custom answer checkers
+answerCustom.pl - Provides custom answer checkers.
 
 =cut
 

--- a/macros/answers/answerHints.pl
+++ b/macros/answers/answerHints.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-answerHints.pl - provides methods for answer hints
+answerHints.pl - Provides methods for answer hints.
 
 =head1 DESCRIPTION
 

--- a/macros/answers/answerVariableList.pl
+++ b/macros/answers/answerVariableList.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-answerVariableList.pl - answer checker for list of variables
+answerVariableList.pl - Answer checker for a list of variables.
 
 =head1 DESCRIPTION
 

--- a/macros/answers/extraAnswerEvaluators.pl
+++ b/macros/answers/extraAnswerEvaluators.pl
@@ -6,7 +6,7 @@ and lists of points.
 
 =head1 DESCRIPTION
 
-This is a list of macros that create "answer evaluators" for checking student
+This is a list of functions that create "answer evaluators" for checking student
 answers of various "exotic" types.
 
 =head1 SYNOPSIS

--- a/macros/answers/unorderedAnswer.pl
+++ b/macros/answers/unorderedAnswer.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-unorderedAnswer.pl - allow the answers to be checked independent of order
+unorderedAnswer.pl - Allow the answers to be checked independent of order.
 
 =head1 SYNOPSIS
 

--- a/macros/answers/weightedGrader.pl
+++ b/macros/answers/weightedGrader.pl
@@ -5,13 +5,16 @@ weightedGrader.pl - This provides weights for each answer.
 
 =head1 DESCRIPTION
 
+Note: This macro should not be used anymore. The functionality of this macro is
+now integrated into the default C<avg_problem_grader>.  See
+L<PGanswermacros.pl/avg_problem_grader>.
+
 A weighted grader that allows you to assign arbitrary percentages
 to the various answers in a problem.  It also allows you to indicate
 that answering one part correctly will give you credit for some
 other part(s).  This way, if there are several parts leading up to
 a "goal" answer, and the student produces the goal answer by
 some other means, he can be given full credit for the problem anyway.
-
 
 =head2 WEIGHTED ANSWERS:
 


### PR DESCRIPTION
Mostly just capitalization and punctuation of the name section.

Note that a comment was added to the `weightedGrader.pl` macro regarding the fact that the functionality of the macro is now in the default `avg_problem_grader`, and that should be used instead of the macro.